### PR TITLE
Revert to script with dependencies to fix broken global header nav

### DIFF
--- a/settings/src/block.json
+++ b/settings/src/block.json
@@ -17,7 +17,7 @@
 	"textdomain": "wporg",
 	"editorScript": "file:./index.js",
 	"editorStyle": "file:./index.css",
-	"viewScript": [ "file:./script.js", "zxcvbn-async", "two-factor-qr-code-generator" ],
+	"script": [ "file:./script.js", "zxcvbn-async", "two-factor-qr-code-generator" ],
 	"style": [ "file:./style-index.css", "wp-components" ],
 	"render": "file:./render.php"
 }

--- a/wporg-two-factor.php
+++ b/wporg-two-factor.php
@@ -238,7 +238,3 @@ function get_edit_account_url() : string {
 
 	return $url;
 }
-
-// Temp fix for TOTP QR code being broken, see: https://meta.trac.wordpress.org/timeline?from=2023-02-21T04%3A40%3A07Z&precision=second.
-remove_filter( 'block_type_metadata', 'gutenberg_block_type_metadata_multiple_view_scripts' );
-remove_filter( 'block_type_metadata_settings', 'gutenberg_block_type_metadata_view_script', 10, 2 );


### PR DESCRIPTION
The temporary fix we added to fix dependency enqueuing for this plugin, has stopped dependencies of the global header being enqueued.