### PR TITLE
Convert password reset parent container into a `<form>`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ WordPress.org-specific customizations for the Two Factor plugin
 1. Open `wp-admin/options-general.php?page=bbpress` and uncheck `Prefix all forum content with the Forum Root slug (Recommended)`, then save.
 1. Visit https://example.org/users/{username}/edit/account/ to view the custom settings UI. If you get a `404` error, visit `wp-admin/options-permalinks.php` and then try again.
 
+## Testing
+
+Front-end unit tests can be run in `/settings` using the `npm run test:unit` command.
+
 ## Security
 
 Please privately report any potential security issues to the [WordPress HackerOne](https://hackerone.com/wordpress) program.

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ WordPress.org-specific customizations for the Two Factor plugin
 
 Front-end unit tests can be run in `/settings` using the `npm run test:unit` command.
 
+Back-end unit tests can be run in `/` using the `composer run test` or `composer run test:watch` commands. `composer run coverage` will generate a coverage report.
+
 ## Security
 
 Please privately report any potential security issues to the [WordPress HackerOne](https://hackerone.com/wordpress) program.

--- a/settings/package.json
+++ b/settings/package.json
@@ -15,10 +15,10 @@
 		"test:unit": "wp-scripts test-unit-js"
 	},
 	"dependencies": {
-		"@automattic/generate-password": "^0.1.0",
-		"@testing-library/react": "^14.0.0"
+		"@automattic/generate-password": "^0.1.0"
 	},
 	"devDependencies": {
+		"@testing-library/react": "^14.0.0",
 		"@wordpress/api-fetch": "^6.24.0",
 		"@wordpress/base-styles": "^4.17.0",
 		"@wordpress/components": "^23.4.0",

--- a/settings/package.json
+++ b/settings/package.json
@@ -11,14 +11,21 @@
 		"lint:css": "wp-scripts lint-style",
 		"lint:js": "wp-scripts lint-js",
 		"packages-update": "wp-scripts packages-update",
-		"start": "wp-scripts start --webpack-copy-php"
+		"start": "wp-scripts start --webpack-copy-php",
+		"test:unit": "wp-scripts test-unit-js"
 	},
 	"dependencies": {
-		"@automattic/generate-password": "^0.1.0"
+		"@automattic/generate-password": "^0.1.0",
+		"@testing-library/react": "^14.0.0"
 	},
 	"devDependencies": {
+		"@wordpress/api-fetch": "^6.24.0",
 		"@wordpress/base-styles": "^4.17.0",
-		"@wordpress/icons": "^9.14.0",
+		"@wordpress/components": "^23.4.0",
+		"@wordpress/core-data": "^6.4.0",
+		"@wordpress/data": "^8.4.0",
+		"@wordpress/element": "^5.4.0",
+		"@wordpress/icons": "^9.18.0",
 		"@wordpress/scripts": "^24.6.0"
 	}
 }

--- a/settings/src/components/password.js
+++ b/settings/src/components/password.js
@@ -39,7 +39,8 @@ export default function Password() {
 	}, [ userRecord.hasEdits ] );
 
 	useEffect( () => {
-		if ( ! userRecord.editedRecord.password ) {
+		// We don't want to check if the user hasn't edited the password in this session
+		if ( ! userRecord.hasEdits || ! userRecord.editedRecord.password ) {
 			return;
 		}
 

--- a/settings/src/components/password.js
+++ b/settings/src/components/password.js
@@ -27,7 +27,14 @@ import { GlobalContext } from '../script';
 export default function Password() {
 	const { setGlobalNotice, userRecord } = useContext( GlobalContext );
 	const [ inputType, setInputType ]     = useState( 'password' );
-	const [ passwordStrong, setPasswordStrong ] = useState( true );
+	let passwordStrong = true; // Saved passwords have already passed the test.
+
+	if ( userRecord.hasEdits ) {
+		passwordStrong = isPasswordStrong(
+			userRecord.editedRecord.password,
+			userRecord.record
+		);
+	}
 
 	// Clear the "saved password" notice when password is being changed.
 	useEffect( () => {
@@ -37,15 +44,6 @@ export default function Password() {
 
 		setGlobalNotice( '' );
 	}, [ userRecord.hasEdits ] );
-
-	useEffect( () => {
-		// We don't want to check if the user hasn't edited the password in this session
-		if ( ! userRecord.hasEdits || ! userRecord.editedRecord.password ) {
-			return;
-		}
-
-		setPasswordStrong( isPasswordStrong( userRecord.editedRecord.password, userRecord.record ) );
-	}, [ userRecord.editedRecord.password ] );
 
 	/**
 	 * Handle clicking the `Generate Password` button.

--- a/settings/src/components/password.js
+++ b/settings/src/components/password.js
@@ -61,7 +61,7 @@ export default function Password() {
 	}, [] );
 
 	// Handle form submission.
-	const handleFormSubmit = useCallback( async ( event ) => {
+	const formSubmitHandler = useCallback( async ( event ) => {
 		event.preventDefault();
 
 		if ( ! passwordStrong || userRecord.isSaving ) {
@@ -82,7 +82,7 @@ export default function Password() {
 	}, [ passwordStrong ] );
 
 	return (
-		<form onSubmit={ handleFormSubmit }>
+		<form onSubmit={ formSubmitHandler }>
 			<p>
 				To update your password enter a new one below.
 				Strong passwords are random, at least twenty characters long, and include uppercase letters and symbols.

--- a/settings/src/components/password.js
+++ b/settings/src/components/password.js
@@ -74,7 +74,7 @@ export default function Password() {
 		apiFetch.nonceMiddleware.nonce = await response.text();
 
 		setGlobalNotice( 'New password saved.' );
-	}, [ passwordStrong ] );
+	}, [ passwordStrong, userRecord.isSaving ] );
 
 	return (
 		<form onSubmit={ formSubmitHandler }>

--- a/settings/src/components/password.js
+++ b/settings/src/components/password.js
@@ -39,6 +39,10 @@ export default function Password() {
 	}, [ userRecord.hasEdits ] );
 
 	useEffect( () => {
+		if ( ! userRecord.editedRecord.password ) {
+			return;
+		}
+
 		setPasswordStrong( isPasswordStrong( userRecord.editedRecord.password, userRecord.record ) );
 	}, [ userRecord.editedRecord.password ] );
 
@@ -130,6 +134,7 @@ export default function Password() {
 				<Button
 					isPrimary
 					disabled={ passwordStrong && ! userRecord.isSaving ? '' : 'disabled' }
+					type="submit"
 				>
 					{ userRecord.isSaving ? 'Saving...' : 'Save password' }
 				</Button>

--- a/settings/src/components/password.js
+++ b/settings/src/components/password.js
@@ -56,7 +56,8 @@ export default function Password() {
 	}, [] );
 
 	// Handle clicking the `Save Password` button.
-	const savePasswordHandler = useCallback( async () => {
+	const handleFormSubmit = useCallback( async ( event ) => {
+		event.preventDefault();
 		await userRecord.save();
 
 		// Changing the password resets the nonce, which causes subsequent API requests to fail. `apiFetch()` will
@@ -71,7 +72,7 @@ export default function Password() {
 	}, [] );
 
 	return (
-		<>
+		<form onSubmit={ handleFormSubmit }>
 			<p>
 				To update your password enter a new one below.
 				Strong passwords are random, at least twenty characters long, and include uppercase letters and symbols.
@@ -124,7 +125,6 @@ export default function Password() {
 				<Button
 					isPrimary
 					disabled={ passwordStrong && ! userRecord.isSaving ? '' : 'disabled' }
-					onClick={ savePasswordHandler }
 				>
 					{ userRecord.isSaving ? 'Saving...' : 'Save password' }
 				</Button>
@@ -138,7 +138,7 @@ export default function Password() {
 					</Button>
 				}
 			</p>
-		</>
+		</form>
 	);
 }
 

--- a/settings/src/components/password.js
+++ b/settings/src/components/password.js
@@ -27,13 +27,10 @@ import { GlobalContext } from '../script';
 export default function Password() {
 	const { setGlobalNotice, userRecord } = useContext( GlobalContext );
 	const [ inputType, setInputType ]     = useState( 'password' );
-	let passwordStrong = true; // Saved passwords have already passed the test.
+	let passwordStrong                    = true; // Saved passwords have already passed the test.
 
 	if ( userRecord.hasEdits ) {
-		passwordStrong = isPasswordStrong(
-			userRecord.editedRecord.password,
-			userRecord.record
-		);
+		passwordStrong = isPasswordStrong( userRecord.editedRecord.password, userRecord.record );
 	}
 
 	// Clear the "saved password" notice when password is being changed.

--- a/settings/src/components/tests/password/mocks.js
+++ b/settings/src/components/tests/password/mocks.js
@@ -1,0 +1,14 @@
+export const mockPasswordEstimator = ( returnValue = 0 ) => {
+	// Mock the zxcvbn library
+	global.window = Object.create( window );
+	Object.defineProperty( window, 'zxcvbn', {
+		value: () => {
+			return {
+				score: returnValue, // at less than 4
+			};
+		},
+		writable: true,
+		enumerable: true,
+		configurable: true,
+	} );
+};

--- a/settings/src/components/tests/password/mocks.js
+++ b/settings/src/components/tests/password/mocks.js
@@ -10,7 +10,7 @@ export const mockPasswordEstimator = ( returnValue = 0 ) => {
 	Object.defineProperty( window, 'zxcvbn', {
 		value: () => {
 			return {
-				score: returnValue, // at less than 4
+				score: returnValue, // at less than or equal to 4
 			};
 		},
 		writable: true,

--- a/settings/src/components/tests/password/mocks.js
+++ b/settings/src/components/tests/password/mocks.js
@@ -1,3 +1,9 @@
+/**
+ * Adds the zxcvbn library to the global window object for testing purposes.
+ *
+ * @param {number} returnValue The score that is returned by the mocked zxcvbn library.
+ * @return {Object}
+ */
 export const mockPasswordEstimator = ( returnValue = 0 ) => {
 	// Mock the zxcvbn library
 	global.window = Object.create( window );

--- a/settings/src/components/tests/password/password.test.js
+++ b/settings/src/components/tests/password/password.test.js
@@ -155,8 +155,8 @@ describe( 'Password', () => {
 
 		useContext.mockReturnValue( mockContext );
 
-		// We'll mock the password estimator to return a score of 10.
-		mockPasswordEstimator( 10 );
+		// We'll mock the password estimator to return a score of 4.
+		mockPasswordEstimator( 4 );
 
 		const { getAllByRole } = render( <Password />, {
 			wrapper: ( { children } ) => (

--- a/settings/src/components/tests/password/password.test.js
+++ b/settings/src/components/tests/password/password.test.js
@@ -1,0 +1,122 @@
+/**
+ * External dependencies
+ */
+import { render, fireEvent, screen } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import { useContext } from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Local dependencies
+ */
+import { GlobalContext } from '../../../script';
+import Password from '../../password';
+import { mockPasswordEstimator } from './mocks';
+
+// Mock the context
+jest.mock( '@wordpress/element', () => ( {
+	...jest.requireActual( '@wordpress/element' ),
+	useContext: jest.fn(),
+} ) );
+
+// Mock the return value of any api calls
+jest.mock( '@wordpress/api-fetch' );
+apiFetch.mockReturnValueOnce(
+	Promise.resolve( {
+		text: jest.fn(),
+	} )
+);
+
+// We set this after making a request.
+apiFetch.nonceMiddleware = { nonce: '' };
+
+// Default mock context
+const mockContext = {
+	userRecord: {
+		editedRecord: {
+			password: 'password',
+		},
+		edit: jest.fn(),
+		save: jest.fn(),
+		hasEdits: false,
+		record: {
+			'2fa_required': true,
+		},
+	},
+	setGlobalNotice: jest.fn(),
+};
+
+describe( 'Password', () => {
+	it( 'should display the weak password notice', () => {
+		// State: he user has updated their password to something weak
+		// although the strength is not tested here.
+		mockContext.userRecord.editedRecord.password = 'weak';
+		mockContext.userRecord.hasEdits = true;
+
+		useContext.mockReturnValue( mockContext );
+
+        // We'll mock the password estimator to return a score of 1.
+		mockPasswordEstimator( 1 );
+
+		const { queryAllByText } = render( <Password />, {
+			wrapper: ( { children } ) => (
+				<GlobalContext.Provider value={ mockContext }>
+					{ children }
+				</GlobalContext.Provider>
+			),
+		} );
+
+		// We may have this message multiple times, because of 'speak'.
+		expect(
+			queryAllByText( /That password is too easy to compromise/i ).length
+		).toBeGreaterThanOrEqual( 1 );
+	} );
+
+	it( 'should display the strong password notice', () => {
+		// State: the user has updated their password to something strong
+		// although the strength is not tested here.
+		mockContext.userRecord.editedRecord.password = '@#4asdf34asdfasdf';
+		mockContext.userRecord.hasEdits = true;
+
+		useContext.mockReturnValue( mockContext );
+
+        // We'll mock the password estimator to return a score of 10.
+		mockPasswordEstimator( 10 );
+
+		const { queryAllByText } = render( <Password />, {
+			wrapper: ( { children } ) => (
+				<GlobalContext.Provider value={ mockContext }>
+					{ children }
+				</GlobalContext.Provider>
+			),
+		} );
+
+		// We may have this message multiple times, because of 'speak'.
+		expect(
+			queryAllByText( /Your password is strong enough to be saved./i )
+				.length
+		).toBeGreaterThanOrEqual( 1 );
+	} );
+
+	it( 'should update the user record password', () => {
+		useContext.mockReturnValue( mockContext );
+
+		const { getByLabelText } = render( <Password />, {
+			wrapper: ( { children } ) => (
+				<GlobalContext.Provider value={ mockContext }>
+					{ children }
+				</GlobalContext.Provider>
+			),
+		} );
+
+		const input = getByLabelText( 'New Password' );
+		const password = 'this is a password';
+		fireEvent.change( input, { target: { value: password } } );
+		expect( mockContext.userRecord.edit ).toHaveBeenCalledWith( {
+			password: password,
+		} );
+	} );
+} );

--- a/settings/src/components/tests/password/password.test.js
+++ b/settings/src/components/tests/password/password.test.js
@@ -24,33 +24,36 @@ jest.mock( '@wordpress/element', () => ( {
 
 // Mock the return value of any api calls
 jest.mock( '@wordpress/api-fetch' );
-apiFetch.mockReturnValueOnce(
-	Promise.resolve( {
-		text: jest.fn(),
-	} )
-);
 
 // We set this after making a request.
 apiFetch.nonceMiddleware = { nonce: '' };
 
 // Default mock context
-const mockContext = {
-	userRecord: {
-		editedRecord: {
-			password: 'password',
-		},
-		edit: jest.fn(),
-		save: jest.fn(),
-		hasEdits: false,
-		record: {
-			'2fa_required': true,
-		},
-		isSaving: false,
-	},
-	setGlobalNotice: jest.fn(),
+let mockContext =  {
+    userRecord: {
+        editedRecord: {
+            password: 'password',
+        },
+        edit: jest.fn(),
+        save: jest.fn(),
+        hasEdits: false,
+        record: {
+            '2fa_required': true,
+        },
+        isSaving: false,
+    },
+    setGlobalNotice: jest.fn(),
 };
 
 describe( 'Password', () => {
+	beforeAll( () => {
+		apiFetch.mockReturnValue(
+			Promise.resolve( {
+				text: jest.fn(),
+			} )
+		);
+	} );
+
 	afterEach( () => {
 		mockContext.userRecord.edit.mockReset();
 		mockContext.userRecord.save.mockReset();
@@ -171,6 +174,23 @@ describe( 'Password', () => {
 			( button ) => button.type === 'submit'
 		)[ 0 ];
 		fireEvent.click( saveButton );
+
+		expect( mockContext.userRecord.save ).toBeCalled();
+	} );
+
+	it( 'should submit form on enter', () => {
+		useContext.mockReturnValue( mockContext );
+
+		const { getByLabelText } = render( <Password />, {
+			wrapper: ( { children } ) => (
+				<GlobalContext.Provider value={ mockContext }>
+					{ children }
+				</GlobalContext.Provider>
+			),
+		} );
+
+		const input = getByLabelText( 'New Password' );
+		fireEvent.submit( input );
 
 		expect( mockContext.userRecord.save ).toBeCalled();
 	} );

--- a/settings/src/components/tests/password/password.test.js
+++ b/settings/src/components/tests/password/password.test.js
@@ -78,7 +78,7 @@ describe( 'Password', () => {
 		} );
 
 		it( 'should display the weak password notice', () => {
-			// State: he user has updated their password to something weak
+			// State: the user has updated their password to something weak
 			// although the strength is not tested here.
 			mockContext.userRecord.editedRecord.password = 'weak';
 			mockContext.userRecord.hasEdits = true;

--- a/settings/src/components/tests/password/password.test.js
+++ b/settings/src/components/tests/password/password.test.js
@@ -110,8 +110,8 @@ describe( 'Password', () => {
 
 			useContext.mockReturnValue( mockContext );
 
-			// We'll mock the password estimator to return a score of 10.
-			mockPasswordEstimator( 10 );
+			// We'll mock the password estimator to return a score of 4.
+			mockPasswordEstimator( 4 );
 
 			const { queryAllByText } = render( <Password />, {
 				wrapper: ( { children } ) => (

--- a/settings/src/components/tests/password/password.test.js
+++ b/settings/src/components/tests/password/password.test.js
@@ -29,20 +29,20 @@ jest.mock( '@wordpress/api-fetch' );
 apiFetch.nonceMiddleware = { nonce: '' };
 
 // Default mock context
-let mockContext =  {
-    userRecord: {
-        editedRecord: {
-            password: 'password',
-        },
-        edit: jest.fn(),
-        save: jest.fn(),
-        hasEdits: false,
-        record: {
-            '2fa_required': true,
-        },
-        isSaving: false,
-    },
-    setGlobalNotice: jest.fn(),
+const mockContext = {
+	userRecord: {
+		editedRecord: {
+			password: 'password',
+		},
+		edit: jest.fn(),
+		save: jest.fn(),
+		hasEdits: false,
+		record: {
+			'2fa_required': true,
+		},
+		isSaving: false,
+	},
+	setGlobalNotice: jest.fn(),
 };
 
 describe( 'Password', () => {
@@ -175,7 +175,7 @@ describe( 'Password', () => {
 		)[ 0 ];
 		fireEvent.click( saveButton );
 
-		expect( mockContext.userRecord.save ).toBeCalled();
+		expect( mockContext.userRecord.save ).toHaveBeenCalled();
 	} );
 
 	it( 'should submit form on enter', () => {
@@ -192,6 +192,6 @@ describe( 'Password', () => {
 		const input = getByLabelText( 'New Password' );
 		fireEvent.submit( input );
 
-		expect( mockContext.userRecord.save ).toBeCalled();
+		expect( mockContext.userRecord.save ).toHaveBeenCalled();
 	} );
 } );

--- a/settings/src/components/tests/password/password.test.js
+++ b/settings/src/components/tests/password/password.test.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { render, fireEvent, screen } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 
 /**
  * WordPress dependencies
@@ -117,10 +117,10 @@ describe( 'Password', () => {
 		} );
 
 		const input = getByLabelText( 'New Password' );
-		const password = 'this is a password';
-		fireEvent.change( input, { target: { value: password } } );
+		const newPassword = 'this is a password';
+		fireEvent.change( input, { target: { value: newPassword } } );
 		expect( mockContext.userRecord.edit ).toHaveBeenCalledWith( {
-			password: password,
+			password: newPassword,
 		} );
 	} );
 } );

--- a/settings/src/components/tests/password/password.test.js
+++ b/settings/src/components/tests/password/password.test.js
@@ -50,6 +50,10 @@ const mockContext = {
 };
 
 describe( 'Password', () => {
+	afterEach( () => {
+		jest.resetAllMocks();
+	} );
+
 	it( 'should display the weak password notice', () => {
 		// State: he user has updated their password to something weak
 		// although the strength is not tested here.
@@ -58,7 +62,7 @@ describe( 'Password', () => {
 
 		useContext.mockReturnValue( mockContext );
 
-        // We'll mock the password estimator to return a score of 1.
+		// We'll mock the password estimator to return a score of 1.
 		mockPasswordEstimator( 1 );
 
 		const { queryAllByText } = render( <Password />, {
@@ -83,7 +87,7 @@ describe( 'Password', () => {
 
 		useContext.mockReturnValue( mockContext );
 
-        // We'll mock the password estimator to return a score of 10.
+		// We'll mock the password estimator to return a score of 10.
 		mockPasswordEstimator( 10 );
 
 		const { queryAllByText } = render( <Password />, {


### PR DESCRIPTION
This PR gives users the ability to update their password via pressing the enter key.

## Changes
1. Turn `passwordStrong` to be a state variable
2. Move form handling from `<button>` to `<form>` event handler. 

## Unit tests
I've added some unit tests to protect these code changes. Ideally, the `<form>` component would be its own component which would make testing easier but I didn't want to make those changes here. As a result, I couldn't easily test everything, I couldn't figure out how to test the `onSubmit` change here using `mocks` and `spies`. 🤔 

It also will help making changes in #53.

## How to test
**Shouldn't submit when field is `empty || has a weak password`**
1. Tab/Click into input field
2. Hit enter
4. Form should not submit
5. Type password "pass"
6. Hit 'enter'
7. Form should not submit

**Should submit - Enter**
1. Tab/Click into input field
2. Type a secure password
3. Hit 'enter'
4. Form should submit

**Should submit - Button Click**
1. Tab/Click into input field
2. Type a secure password
3. Click 'enter'
4. Form should submit

**Should submit - Generate passsword**
1. Click "Generate strong password"
2. Slick "Save password"
3. Form should submit.

