### PR TITLE
Use bbPress email confirm url rather than core's.

### DIFF
--- a/settings/rest-api.php
+++ b/settings/rest-api.php
@@ -196,6 +196,28 @@ function require_email_confirmation( $insert_data, $request ) {
 	if ( isset( $insert_data->user_email ) ) {
 		$post_backup = $_POST;
 
+		// Switch out the core wp-admin confirmation url with bbPress's.
+		if ( function_exists( 'bbp_get_user_profile_edit_url' ) ) {
+			add_filter( 'new_user_email_content', function( $email_text ) {
+				$user_hash   = get_user_meta( $_POST['user_id'], '_new_email', true );
+				$confirm_url = add_query_arg(
+					[
+						'action'       => 'bbp-update-user-email',
+						'newuseremail' => $user_hash['hash']
+					],
+					bbp_get_user_profile_edit_url( $_POST['user_id'] )
+				);
+
+				$email_text = str_replace(
+					'###ADMIN_URL###',
+					esc_url_raw( $confirm_url ),
+					$email_text
+				);
+
+				return $email_text;
+			} );
+		}
+
 		// The POST fields needed by send_confirmation_on_profile_email().
 		$_POST['user_id'] = $insert_data->ID;
 		$_POST['email']   = $insert_data->user_email;


### PR DESCRIPTION
This PR partially fixes #67 in a good-enough manner.

It overwrites the `wp-admin/profile.php?newemailhash=....` URL with the bbPress variant of it instead, which allows for users who do not have wp-admin access to confirm their email.

This filter can be removed if https://github.com/WordPress/wordpress-develop/pull/3813 is merged.

|Before|After|
|---|---|
| <img width="734" alt="Screenshot 2023-02-23 at 5 44 16 pm" src="https://user-images.githubusercontent.com/767313/220847113-d50da051-f9bd-49d9-a004-f2263705be8a.png"> |  <img width="883" alt="Screenshot 2023-02-23 at 5 43 22 pm" src="https://user-images.githubusercontent.com/767313/220847197-59867488-98ce-4f73-8bc0-b6c9d7bc92a2.png"> |

