### PR TITLE
Turn off 2FA if the user only has Backup Codes enabled

### DIFF
--- a/tests/test-wporg-two-factor.php
+++ b/tests/test-wporg-two-factor.php
@@ -217,21 +217,21 @@ class Test_WPorg_Two_Factor extends WP_UnitTestCase {
 		// Set backup codes as primary.
 		$backup_codes_provider = Two_Factor_Backup_Codes::get_instance();
 		$backup_codes_provider->generate_codes( self::$regular_user );
-		Two_Factor_Core::enable_provider_for_user( self::$regular_user->ID, 'Two_Factor_Backup_Codes' );
-		update_user_meta( self::$regular_user->ID, Two_Factor_Core::PROVIDER_USER_META_KEY, 'Two_Factor_Backup_Codes' );
+		$enabled = Two_Factor_Core::enable_provider_for_user( self::$regular_user->ID, 'Two_Factor_Backup_Codes' );
 
 		$expected = null;
 		$actual   = Two_Factor_Core::get_primary_provider_for_user( self::$regular_user->ID );
+		$this->assertTrue( $enabled );
 		$this->assertSame( $expected, $actual );
 
 		// Enable TOTP (as secondary).
 		$totp_provider = Two_Factor_Totp::get_instance();
 		$totp_provider->set_user_totp_key( self::$regular_user->ID, Two_Factor_Totp::generate_key() );
-		Two_Factor_Core::enable_provider_for_user( self::$regular_user->ID, 'Two_Factor_Totp' );
+		$enabled = Two_Factor_Core::enable_provider_for_user( self::$regular_user->ID, 'Two_Factor_Totp' );
 
 		$expected = 'Two_Factor_Totp';
 		$actual   = get_class( Two_Factor_Core::get_primary_provider_for_user( self::$regular_user->ID ) );
-
+		$this->assertTrue( $enabled );
 		$this->assertSame( $expected, $actual );
 
 		// Validate that Backup Codes are now available as secondary.

--- a/tests/test-wporg-two-factor.php
+++ b/tests/test-wporg-two-factor.php
@@ -220,8 +220,8 @@ class Test_WPorg_Two_Factor extends WP_UnitTestCase {
 		Two_Factor_Core::enable_provider_for_user( self::$regular_user->ID, 'Two_Factor_Backup_Codes' );
 		update_user_meta( self::$regular_user->ID, Two_Factor_Core::PROVIDER_USER_META_KEY, 'Two_Factor_Backup_Codes' );
 
-		$expected = 'Two_Factor_Backup_Codes';
-		$actual   = get_class( Two_Factor_Core::get_primary_provider_for_user( self::$regular_user->ID ) );
+		$expected = null;
+		$actual   = Two_Factor_Core::get_primary_provider_for_user( self::$regular_user->ID );
 		$this->assertSame( $expected, $actual );
 
 		// Enable TOTP (as secondary).
@@ -231,6 +231,12 @@ class Test_WPorg_Two_Factor extends WP_UnitTestCase {
 
 		$expected = 'Two_Factor_Totp';
 		$actual   = get_class( Two_Factor_Core::get_primary_provider_for_user( self::$regular_user->ID ) );
+
+		$this->assertSame( $expected, $actual );
+
+		// Validate that Backup Codes are now available as secondary.
+		$expected = [ 'Two_Factor_Backup_Codes', 'Two_Factor_Totp' ];
+		$actual   = array_keys( Two_Factor_Core::get_enabled_providers_for_user( self::$regular_user->ID ) );
 
 		$this->assertSame( $expected, $actual );
 	}

--- a/tests/test-wporg-two-factor.php
+++ b/tests/test-wporg-two-factor.php
@@ -236,7 +236,7 @@ class Test_WPorg_Two_Factor extends WP_UnitTestCase {
 
 		// Validate that Backup Codes are now available as secondary.
 		$expected = [ 'Two_Factor_Backup_Codes', 'Two_Factor_Totp' ];
-		$actual   = array_keys( Two_Factor_Core::get_enabled_providers_for_user( self::$regular_user->ID ) );
+		$actual   = Two_Factor_Core::get_enabled_providers_for_user( self::$regular_user );
 
 		$this->assertSame( $expected, $actual );
 	}

--- a/wporg-two-factor.php
+++ b/wporg-two-factor.php
@@ -61,6 +61,11 @@ function set_primary_provider_for_user( string $provider, int $user_id ) : strin
 		$provider = 'Two_Factor_WebAuthn';
 	} elseif ( isset( $available_providers['Two_Factor_Totp'] ) ) {
 		$provider = 'Two_Factor_Totp';
+	} elseif ( 'Two_Factor_Backup_Codes' === $provider && 1 === count( $available_providers ) ) {
+		/*
+		 * If we only have Backup Codes enabled, 2FA is disabled on WordPress.org.
+		 */
+		$provider = '';
 	}
 
 	return $provider;

--- a/wporg-two-factor.php
+++ b/wporg-two-factor.php
@@ -34,7 +34,7 @@ add_filter( 'two_factor_totp_issuer', __NAMESPACE__ . '\set_totp_issuer' );
 add_action( 'set_current_user', __NAMESPACE__ . '\remove_super_admins_until_2fa_enabled', 1 ); // Must run _before_ all other plugins.
 add_action( 'login_redirect', __NAMESPACE__ . '\redirect_to_2fa_settings', 105, 3 ); // After `wporg_remember_where_user_came_from_redirect()`, before `WP_WPorg_SSO::redirect_to_policy_update()`.
 add_action( 'user_has_cap', __NAMESPACE__ . '\remove_capabilities_until_2fa_enabled', 99, 4 ); // Must run _after_ all other plugins.
-add_filter( 'two_factor_primary_provider_for_user', __NAMESPACE__ . '\disable_only_backup_codes', 10, 2 );
+
 
 /**
  * Determine which providers should be available to users.
@@ -237,27 +237,6 @@ function get_edit_account_url() : string {
 	}
 
 	return $url;
-}
-
-
-/**
- * Disable 2FA for users who only have backup codes enabled.
- *
- * @param string|null $primary_provider The currently selected Primary provider.
- * @param int         $user_id          The user ID.
- * @return string|null The primary provider, or null.
- */
-function disable_only_backup_codes( $primary_provider, $user_id ) {
-	if ( 'Two_Factor_Backup_Codes' === $primary_provider ) {
-		$user      = get_user_by( 'id', $user_id );
-		$providers = $user ? Two_Factor_Core::get_enabled_providers_for_user( $user ) : [];
-
-		if ( 1 === count( $providers ) ) {
-			$primary_provider = null;
-		}
-	}
-
-	return $primary_provider;
 }
 
 // Temp fix for TOTP QR code being broken, see: https://meta.trac.wordpress.org/timeline?from=2023-02-21T04%3A40%3A07Z&precision=second.

--- a/wporg-two-factor.php
+++ b/wporg-two-factor.php
@@ -34,7 +34,7 @@ add_filter( 'two_factor_totp_issuer', __NAMESPACE__ . '\set_totp_issuer' );
 add_action( 'set_current_user', __NAMESPACE__ . '\remove_super_admins_until_2fa_enabled', 1 ); // Must run _before_ all other plugins.
 add_action( 'login_redirect', __NAMESPACE__ . '\redirect_to_2fa_settings', 105, 3 ); // After `wporg_remember_where_user_came_from_redirect()`, before `WP_WPorg_SSO::redirect_to_policy_update()`.
 add_action( 'user_has_cap', __NAMESPACE__ . '\remove_capabilities_until_2fa_enabled', 99, 4 ); // Must run _after_ all other plugins.
-
+add_filter( 'two_factor_primary_provider_for_user', __NAMESPACE__ . '\disable_only_backup_codes', 10, 2 );
 
 /**
  * Determine which providers should be available to users.
@@ -237,6 +237,27 @@ function get_edit_account_url() : string {
 	}
 
 	return $url;
+}
+
+
+/**
+ * Disable 2FA for users who only have backup codes enabled.
+ *
+ * @param string|null $primary_provider The currently selected Primary provider.
+ * @param int         $user_id          The user ID.
+ * @return string|null The primary provider, or null.
+ */
+function disable_only_backup_codes( $primary_provider, $user_id ) {
+	if ( 'Two_Factor_Backup_Codes' === $primary_provider ) {
+		$user      = get_user_by( 'id', $user_id );
+		$providers = $user ? Two_Factor_Core::get_enabled_providers_for_user( $user ) : [];
+
+		if ( 1 === count( $providers ) ) {
+			$primary_provider = null;
+		}
+	}
+
+	return $primary_provider;
 }
 
 // Temp fix for TOTP QR code being broken, see: https://meta.trac.wordpress.org/timeline?from=2023-02-21T04%3A40%3A07Z&precision=second.


### PR DESCRIPTION
This is partially related to #47 and might fix it, I'm not sure.

This simply disables 2FA if the user only has Backup Codes enabled, which appears to be happening for users when _viewing the TOTP screen, but not setting it up_ (This is a bug in our UI, partially due to a less-than-ideal upstream flow).

The result from that is that they're locked out, as they never saw the backup codes, and are prompted for them next time they login. There are currently ~5 users affected by this.

This PR should resolve the login for those users, and might resolve #47.