### PR TITLE
Fix "show password" icon styles

### DIFF
--- a/settings/package.json
+++ b/settings/package.json
@@ -15,8 +15,7 @@
 		"test:unit": "wp-scripts test-unit-js"
 	},
 	"dependencies": {
-		"@automattic/generate-password": "^0.1.0",
-		"lodash": "^4.17.21"
+		"@automattic/generate-password": "^0.1.0"
 	},
 	"devDependencies": {
 		"@testing-library/react": "^14.0.0",

--- a/settings/package.json
+++ b/settings/package.json
@@ -26,6 +26,7 @@
 		"@wordpress/data": "^8.4.0",
 		"@wordpress/element": "^5.4.0",
 		"@wordpress/icons": "^9.18.0",
-		"@wordpress/scripts": "^24.6.0"
+		"@wordpress/scripts": "^24.6.0",
+		"lodash": "^4.17.21"
 	}
 }

--- a/settings/package.json
+++ b/settings/package.json
@@ -15,7 +15,8 @@
 		"test:unit": "wp-scripts test-unit-js"
 	},
 	"dependencies": {
-		"@automattic/generate-password": "^0.1.0"
+		"@automattic/generate-password": "^0.1.0",
+		"lodash": "^4.17.21"
 	},
 	"devDependencies": {
 		"@testing-library/react": "^14.0.0",

--- a/settings/src/components/password.js
+++ b/settings/src/components/password.js
@@ -3,7 +3,7 @@
  *
  * window.zxcvbn is also used, but can't be enqueued via an `import` because the handle doesn't have a 'wp-'
  * prefix. Instead, it's enqueued via `block.json`. It also can't be declared/destructured here because it's
- * loaded asyncronously.
+ * loaded asynchronously.
  */
 import { pick } from 'lodash';
 import { generatePassword } from '@automattic/generate-password';
@@ -200,7 +200,7 @@ export default function Password() {
  * @return {boolean} true if the password is strong, false otherwise
  */
 function isPasswordStrong( password, userData ) {
-	const { zxcvbn } = window; // Done here because it's loaded asyncronously.
+	const { zxcvbn } = window; // Done here because it's loaded asynchronously.
 
 	if ( ! zxcvbn ) {
 		return false; // Not loaded yet.

--- a/settings/src/components/password.js
+++ b/settings/src/components/password.js
@@ -64,7 +64,7 @@ export default function Password() {
 	 * to update the `passwordStrong` state. Is there a way to tell React to wait until both are done to re-render?
 	 * Or maybe the condition that renders the notice can include something like `hasResolved`?
 	 */
-	const generatePasswordHandler = useCallback( async () => {
+	const handlePasswordGenerate = useCallback( async () => {
 		userRecord.edit( { password: generatePassword( 24, true, true ) } );
 		setInputType( 'text' );
 	}, [] );
@@ -181,7 +181,7 @@ export default function Password() {
 				</Button>
 
 				{ window.crypto?.getRandomValues && (
-					<Button isSecondary onClick={ generatePasswordHandler }>
+					<Button isSecondary onClick={ handlePasswordGenerate }>
 						Generate strong password
 					</Button>
 				) }

--- a/settings/src/components/password.js
+++ b/settings/src/components/password.js
@@ -101,7 +101,6 @@ export default function Password() {
 					placeholder="Q1jtBPRmROv51KOtbZ5aIKrc"
 					onChange={ ( password ) => userRecord.edit( { password } ) }
 				/>
-
 				<Button
 					className="wporg-2fa__show-password"
 					size={ 24 }

--- a/settings/src/components/password.js
+++ b/settings/src/components/password.js
@@ -11,10 +11,21 @@ import { generatePassword } from '@automattic/generate-password';
 /**
  * WordPress dependencies
  */
-import { Button, Flex, Notice, TextControl }             from '@wordpress/components';
-import { useCallback, useContext, useEffect, useState }  from '@wordpress/element';
-import { Icon, cancelCircleFilled, check, seen, unseen } from '@wordpress/icons';
-import apiFetch                                          from '@wordpress/api-fetch';
+import { Button, Flex, Notice, TextControl } from '@wordpress/components';
+import {
+	useCallback,
+	useContext,
+	useEffect,
+	useState,
+} from '@wordpress/element';
+import {
+	Icon,
+	cancelCircleFilled,
+	check,
+	seen,
+	unseen,
+} from '@wordpress/icons';
+import apiFetch from '@wordpress/api-fetch';
 
 /**
  * Internal dependencies
@@ -26,11 +37,14 @@ import { GlobalContext } from '../script';
  */
 export default function Password() {
 	const { setGlobalNotice, userRecord } = useContext( GlobalContext );
-	const [ inputType, setInputType ]     = useState( 'password' );
-	let passwordStrong                    = true; // Saved passwords have already passed the test.
+	const [ inputType, setInputType ] = useState( 'password' );
+	let passwordStrong = true; // Saved passwords have already passed the test.
 
 	if ( userRecord.hasEdits ) {
-		passwordStrong = isPasswordStrong( userRecord.editedRecord.password, userRecord.record );
+		passwordStrong = isPasswordStrong(
+			userRecord.editedRecord.password,
+			userRecord.record
+		);
 	}
 
 	// Clear the "saved password" notice when password is being changed.
@@ -56,44 +70,54 @@ export default function Password() {
 	}, [] );
 
 	// Handle form submission.
-	const handleFormSubmit = useCallback( async ( event ) => {
-		event.preventDefault();
+	const handleFormSubmit = useCallback(
+		async ( event ) => {
+			event.preventDefault();
 
-		if ( ! passwordStrong || userRecord.isSaving ) {
-			return;
-		}
+			if ( ! passwordStrong || userRecord.isSaving ) {
+				return;
+			}
 
-		await userRecord.save();
+			await userRecord.save();
 
-		// Changing the password resets the nonce, which causes subsequent API requests to fail. `apiFetch()` will
-		// retry them automatically, but that results in an extra XHR request and a console error.
-		const response = await apiFetch( {
-			url:   apiFetch.nonceEndpoint,
-			parse: false
-		} );
-		apiFetch.nonceMiddleware.nonce = await response.text();
+			// Changing the password resets the nonce, which causes subsequent API requests to fail. `apiFetch()` will
+			// retry them automatically, but that results in an extra XHR request and a console error.
+			const response = await apiFetch( {
+				url: apiFetch.nonceEndpoint,
+				parse: false,
+			} );
+			apiFetch.nonceMiddleware.nonce = await response.text();
 
-		setGlobalNotice( 'New password saved.' );
-	}, [ passwordStrong, userRecord.isSaving ] );
+			setGlobalNotice( 'New password saved.' );
+		},
+		[ passwordStrong, userRecord.isSaving ]
+	);
 
 	const handlePasswordChange = useCallback(
-		( password ) => userRecord.edit( { password } ), []
+		( password ) => userRecord.edit( { password } ),
+		[]
 	);
 
 	const handlePasswordToggle = useCallback(
-		() => setInputType(inputType === "password" ? "text" : "password"), [ inputType ]
+		() => setInputType( inputType === 'password' ? 'text' : 'password' ),
+		[ inputType ]
 	);
 
 	return (
 		<form onSubmit={ handleFormSubmit }>
 			<p>
-				To update your password enter a new one below.
-				Strong passwords are random, at least twenty characters long, and include uppercase letters and symbols.
+				To update your password enter a new one below. Strong passwords
+				are random, at least twenty characters long, and include
+				uppercase letters and symbols.
 			</p>
 
 			<p>
-				For convenience, use a password manager to store and automatically enter passwords.
-				For more information, read about <a href="https://wordpress.org/documentation/article/password-best-practices/">password best practices</a>.
+				For convenience, use a password manager to store and
+				automatically enter passwords. For more information, read about{ ' ' }
+				<a href="https://wordpress.org/documentation/article/password-best-practices/">
+					password best practices
+				</a>
+				.
 			</p>
 
 			<Flex className="wporg-2fa__password_container">
@@ -113,44 +137,54 @@ export default function Password() {
 					className="wporg-2fa__show-password"
 					size={ 24 }
 					onClick={ handlePasswordToggle }
-					aria-label={ inputType === "password" ? "Show Password" : "Hide Password" }
-					title={ inputType === "password" ? "Show Password" : "Hide Password" }
+					aria-label={
+						inputType === 'password'
+							? 'Show Password'
+							: 'Hide Password'
+					}
+					title={
+						inputType === 'password'
+							? 'Show Password'
+							: 'Hide Password'
+					}
 				>
-  					<Icon icon={inputType === "password" ? seen : unseen} />
+					<Icon icon={ inputType === 'password' ? seen : unseen } />
 				</Button>
 			</Flex>
 
-			{ userRecord.hasEdits && passwordStrong &&
+			{ userRecord.hasEdits && passwordStrong && (
 				<Notice status="success" isDismissible={ false }>
 					<Icon icon={ check } />
 					Your password is strong enough to be saved.
 				</Notice>
-			}
+			) }
 
-			{ userRecord.hasEdits && ! passwordStrong &&
+			{ userRecord.hasEdits && ! passwordStrong && (
 				<Notice status="error" isDismissible={ false }>
 					<Icon icon={ cancelCircleFilled } />
-					That password is too easy to compromise. Please make it longer and/or add random numbers/symbols.
+					That password is too easy to compromise. Please make it
+					longer and/or add random numbers/symbols.
 				</Notice>
-			}
+			) }
 
 			<p>
 				<Button
 					isPrimary
-					disabled={ passwordStrong && ! userRecord.isSaving ? '' : 'disabled' }
+					disabled={
+						passwordStrong && ! userRecord.isSaving
+							? ''
+							: 'disabled'
+					}
 					type="submit"
 				>
 					{ userRecord.isSaving ? 'Saving...' : 'Save password' }
 				</Button>
 
-				{ window.crypto?.getRandomValues &&
-					<Button
-						isSecondary
-						onClick={ generatePasswordHandler }
-					>
+				{ window.crypto?.getRandomValues && (
+					<Button isSecondary onClick={ generatePasswordHandler }>
 						Generate strong password
 					</Button>
-				}
+				) }
 			</p>
 		</form>
 	);
@@ -161,7 +195,9 @@ export default function Password() {
  *
  * Validation is also done on the backend by `security-weak-passwords.php`.
  *
- * @returns {boolean}
+ * @param {string} password
+ * @param {Object} userData
+ * @return {boolean} true if the password is strong, false otherwise
  */
 function isPasswordStrong( password, userData ) {
 	const { zxcvbn } = window; // Done here because it's loaded asyncronously.
@@ -170,16 +206,24 @@ function isPasswordStrong( password, userData ) {
 		return false; // Not loaded yet.
 	}
 
-	let blocklist = Object.values( pick(
-		userData,
-		[ 'email', 'description', 'first_name', 'last_name', 'name', 'nickname', 'slug', 'username' ]
-	) );
+	let blocklist = Object.values(
+		pick( userData, [
+			'email',
+			'description',
+			'first_name',
+			'last_name',
+			'name',
+			'nickname',
+			'slug',
+			'username',
+		] )
+	);
 	blocklist = blocklist.concat( [ 'wordpress', 'wporg', 'wordpressorg' ] );
 
 	// `3` is "safely unguessable: moderate protection from offline slow-hash scenario. (guesses < 10^10)"
 	// `4` is "very unguessable: strong protection from offline slow-hash scenario. (guesses >= 10^10)"
-	const minimumScore = userData['2fa_required'] ? 4 : 3;
-	const strength     = zxcvbn( password, blocklist );
+	const minimumScore = userData[ '2fa_required' ] ? 4 : 3;
+	const strength = zxcvbn( password, blocklist );
 
 	return strength.score >= minimumScore;
 }

--- a/settings/src/components/password.js
+++ b/settings/src/components/password.js
@@ -56,7 +56,7 @@ export default function Password() {
 	}, [] );
 
 	// Handle form submission.
-	const formSubmitHandler = useCallback( async ( event ) => {
+	const handleFormSubmit = useCallback( async ( event ) => {
 		event.preventDefault();
 
 		if ( ! passwordStrong || userRecord.isSaving ) {
@@ -76,8 +76,16 @@ export default function Password() {
 		setGlobalNotice( 'New password saved.' );
 	}, [ passwordStrong, userRecord.isSaving ] );
 
+	const handlePasswordChange = useCallback(
+		( password ) => userRecord.edit( { password } ), []
+	);
+
+	const handlePasswordToggle = useCallback(
+		() => setInputType(inputType === "password" ? "text" : "password"), [ inputType ]
+	);
+
 	return (
-		<form onSubmit={ formSubmitHandler }>
+		<form onSubmit={ handleFormSubmit }>
 			<p>
 				To update your password enter a new one below.
 				Strong passwords are random, at least twenty characters long, and include uppercase letters and symbols.
@@ -99,12 +107,12 @@ export default function Password() {
 					size="62"
 					value={ userRecord.editedRecord.password ?? '' }
 					placeholder="Q1jtBPRmROv51KOtbZ5aIKrc"
-					onChange={ ( password ) => userRecord.edit( { password } ) }
+					onChange={ handlePasswordChange }
 				/>
 				<Button
 					className="wporg-2fa__show-password"
 					size={ 24 }
-					onClick={ () => setInputType( inputType === 'password' ? 'text' : 'password' ) }
+					onClick={ handlePasswordToggle }
 					aria-label={ inputType === "password" ? "Show Password" : "Hide Password" }
 					title={ inputType === "password" ? "Show Password" : "Hide Password" }
 				>

--- a/settings/src/components/password.js
+++ b/settings/src/components/password.js
@@ -11,10 +11,10 @@ import { generatePassword } from '@automattic/generate-password';
 /**
  * WordPress dependencies
  */
-import { Button, Flex, Notice, TextControl }            from '@wordpress/components';
-import { useCallback, useContext, useEffect, useState } from '@wordpress/element';
-import { Icon, cancelCircleFilled, check, seen }        from '@wordpress/icons';
-import apiFetch                                         from '@wordpress/api-fetch';
+import { Button, Flex, Notice, TextControl }             from '@wordpress/components';
+import { useCallback, useContext, useEffect, useState }  from '@wordpress/element';
+import { Icon, cancelCircleFilled, check, seen, unseen } from '@wordpress/icons';
+import apiFetch                                          from '@wordpress/api-fetch';
 
 /**
  * Internal dependencies
@@ -105,9 +105,10 @@ export default function Password() {
 					className="wporg-2fa__show-password"
 					size={ 24 }
 					onClick={ () => setInputType( inputType === 'password' ? 'text' : 'password' ) }
-					aria-label="Show password"
+					aria-label={ inputType === "password" ? "Show Password" : "Hide Password" }
+					title={ inputType === "password" ? "Show Password" : "Hide Password" }
 				>
-					<Icon icon={ seen } />
+  					<Icon icon={inputType === "password" ? seen : unseen} />
 				</Button>
 			</Flex>
 

--- a/settings/src/components/password.scss
+++ b/settings/src/components/password.scss
@@ -1,5 +1,6 @@
 .wporg-2fa__password,
 .bbp-single-user .wporg-2fa__password {
+
 	.wporg-2fa__password_container {
 		justify-content: flex-start;
 		align-items: flex-start;

--- a/settings/src/components/password.scss
+++ b/settings/src/components/password.scss
@@ -3,13 +3,20 @@
 	.wporg-2fa__password_container {
 		justify-content: flex-start;
 		align-items: flex-start;
+		position: relative;
+		width: fit-content;
+
+		input {
+			padding-right: 35px;
+		}
 	}
 
 	.wporg-2fa__show-password {
-		flex-shrink: 0;
-		position: relative;
-		top: 23px;
+		position: absolute;
+		top: 25px;
+		right: 2px;
 		margin: 0;
-		padding: 0;
+		padding: 0 4px;
+		height: 30px;
 	}
 }

--- a/settings/src/components/password.scss
+++ b/settings/src/components/password.scss
@@ -1,9 +1,5 @@
 .wporg-2fa__password,
 .bbp-single-user .wporg-2fa__password {
-	input[type="text"] {
-		padding: 6px 8px; /* Match .components-text-control__input[type="password"] */
-	}
-
 	.wporg-2fa__password_container {
 		justify-content: flex-start;
 		align-items: flex-start;

--- a/settings/src/components/password.scss
+++ b/settings/src/components/password.scss
@@ -8,6 +8,7 @@
 		width: fit-content;
 
 		input {
+			/* This includes room for the `(un)seen` icon, and also for the icon that 1password etc add to password fields. */
 			padding-right: 35px;
 		}
 	}

--- a/settings/src/components/password.scss
+++ b/settings/src/components/password.scss
@@ -14,10 +14,10 @@
 
 	.wporg-2fa__show-password {
 		position: absolute;
-		top: 25px;
-		right: 2px;
+		top: 24px;
+		right: 1px;
 		margin: 0;
-		padding: 0 4px;
-		height: 30px;
+		padding: 0 5px;
+		height: 31px;
 	}
 }


### PR DESCRIPTION
Fixes #83 

This PR fixes 
* When toggled, the "show password" icon would squeeze the input on the left.
* Make the icon inside the input field. 
* The styles were also modified to accommodate the 1password icon.
* Add a toggled state for the show password icon.
  * The `unseen` icon provided in the issue has already been added to [Gutenberg](https://github.com/WordPress/gutenberg/pull/49254), and it's expected to be in production on GB 15.5, probably 2-3 weeks later. I've opened another [branch](https://github.com/WordPress/wporg-two-factor/compare/testing/show-password-icon-style?expand=1) that had `unseen.svg` included so that it can be tested if anyone wants to.
* Run `lint:js`. 
  * It looks like there were many changes in `settings/src/components/password.js`, but most of them were just linting updates.

## Screencasts
https://user-images.githubusercontent.com/18050944/226954384-86416da1-2925-4f3f-9c2e-98ad3421a4fb.mp4




