### PR TITLE
Add stub for WebAuthn UI

### DIFF
--- a/settings/src/components/account-status.js
+++ b/settings/src/components/account-status.js
@@ -33,7 +33,7 @@ export default function AccountStatus() {
 
 	const backupBodyText =
 		! backupCodesEnabled && ! hasPrimaryProvider
-			? 'Please enable Two-Factor Authentication before enabling backup codes.'
+			? 'Please enable a Two-Factor security key or app before enabling backup codes.'
 			: `You have
 				${ backupCodesEnabled ? '' : 'not' }
 				verified your backup codes for two-factor authentication.`;
@@ -61,12 +61,11 @@ export default function AccountStatus() {
 			<SettingStatusCard
 				screen="totp"
 				status={ totpEnabled }
-				headerText="Two-Factor Authentication"
+				headerText="Two-Factor App"
 				bodyText={
 					totpEnabled
-						? /* @todo update this when hardware tokens become an additional option. */
-						  'You have two-factor authentication enabled using an app.'
-						: 'You do not have two-factor authentication enabled.'
+						? 'You have two-factor authentication enabled using an app.'
+						: 'You have not enabled an app for two-factor authentication.'
 				}
 			/>
 

--- a/settings/src/components/account-status.js
+++ b/settings/src/components/account-status.js
@@ -3,7 +3,7 @@
  */
 import { Card, CardBody } from '@wordpress/components';
 import { useContext } from '@wordpress/element';
-import { Icon, cancelCircleFilled, check, chevronRight, warning } from '@wordpress/icons';
+import { Icon, cancelCircleFilled, check, chevronRight, info, warning } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -60,7 +60,7 @@ export default function AccountStatus() {
 
 			<SettingStatusCard
 				screen="totp"
-				status={ totpEnabled }
+				status={ hasPrimaryProvider && ! totpEnabled ? 'info' : totpEnabled }
 				headerText="Two-Factor App"
 				bodyText={
 					totpEnabled
@@ -132,6 +132,10 @@ function StatusIcon( { status } ) {
 		case 'ok':
 		case 'enabled':
 			icon = check;
+			break;
+
+		case 'info':
+			icon = info;
 			break;
 
 		case 'pending':

--- a/settings/src/components/account-status.js
+++ b/settings/src/components/account-status.js
@@ -28,6 +28,7 @@ export default function AccountStatus() {
 		},
 	} = useContext( GlobalContext );
 	const emailStatus = pendingEmail ? 'pending' : 'ok';
+	const webAuthnEnabled = availableProviders.includes( 'TwoFactor_Provider_WebAuthn' );
 	const totpEnabled = availableProviders.includes( 'Two_Factor_Totp' );
 	const backupCodesEnabled = availableProviders.includes( 'Two_Factor_Backup_Codes' );
 
@@ -57,6 +58,20 @@ export default function AccountStatus() {
 						: `Your account email address is ${ email }.`
 				}
 			/>
+
+			{ /* TODO: Only enable WebAuthn UI in development, until it's finished. */ }
+			{ 'development' === process.env.NODE_ENV && (
+				<SettingStatusCard
+					screen="webauthn"
+					status={ hasPrimaryProvider && ! webAuthnEnabled ? 'info' : webAuthnEnabled }
+					headerText="Two-Factor Security Key"
+					bodyText={
+						webAuthnEnabled
+							? 'You have two-factor authentication enabled using security keys.'
+							: 'You have not registered any security keys.'
+					}
+				/>
+			) }
 
 			<SettingStatusCard
 				screen="totp"

--- a/settings/src/components/account-status.scss
+++ b/settings/src/components/account-status.scss
@@ -65,6 +65,10 @@
 			fill: $alert-green;
 		}
 
+		&.is-info {
+			fill: $alert-blue;
+		}
+
 		&.is-pending {
 			fill: $alert-yellow;
 		}

--- a/settings/src/components/totp.js
+++ b/settings/src/components/totp.js
@@ -330,12 +330,12 @@ function Manage() {
 			</p>
 
 			<p>
-				<strong>Status:</strong> Two-factor authentication is currently{ ' ' }
+				<strong>Status:</strong> Two-Factor app is currently{ ' ' }
 				<span className="wporg-2fa__enabled-status">on</span>.
 			</p>
 
 			<Button isPrimary onClick={ handleDisable }>
-				Disable Two-Factor Authentication
+				Disable Two-Factor app
 			</Button>
 
 			{ error && (

--- a/settings/src/components/webauthn.js
+++ b/settings/src/components/webauthn.js
@@ -1,0 +1,199 @@
+/**
+ * WordPress dependencies
+ */
+import { Button, Spinner, TextControl } from '@wordpress/components';
+import { useCallback, useContext, useState } from '@wordpress/element';
+import { Icon, check } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import { GlobalContext } from '../script';
+
+const confirm = window.confirm;
+
+/**
+ * Render the WebAuthn setting.
+ */
+export default function WebAuthn() {
+	const {
+		user: { userRecord },
+	} = useContext( GlobalContext );
+	const userKeys = userRecord.record[ '2fa_webauthn_keys' ];
+	const backupCodesEnabled =
+		userRecord.record[ '2fa_available_providers' ].includes( 'Two_Factor_Backup_Codes' );
+	const [ step, setStep ] = useState( 'manage' );
+
+	// todo this is just a placeholder. the real one would probably make an API request to save the new key,
+	// and then replace userkeys with the value returned by the call
+	// probably also refreshRecord( userRecord );
+	const onRegisterSuccess = useCallback( () => {
+		userKeys.push( {
+			id: 1111,
+			name: 'New Key',
+		} );
+		setStep( 'success' );
+
+		if ( ! backupCodesEnabled ) {
+			// todo redirect to backup codes
+		}
+	}, [ userKeys ] );
+
+	return (
+		<>
+			{ 'manage' === step && <Manage setStep={ setStep } userKeys={ userKeys } /> }
+
+			{ 'register' === step && (
+				<RegisterKey registerClickHandler={ () => setStep( 'waiting' ) } />
+			) }
+
+			{ 'waiting' === step && (
+				<WaitingForSecurityKey onRegisterSuccess={ onRegisterSuccess } />
+			) }
+
+			{ 'success' === step && <Success newKeyName={ 'Test key' } setStep={ setStep } /> }
+		</>
+	);
+}
+
+/**
+ * Render the Manage component.
+ *
+ * @param props
+ * @param props.setStep
+ * @param props.userKeys
+ */
+function Manage( { setStep, userKeys } ) {
+	return (
+		<>
+			<p>
+				A security key is a physical or software-based device that adds an extra layer of
+				authentication and protection to online accounts. It generates unique codes or
+				cryptographic signatures to verify the user&apos;s identity, offering stronger
+				security than passwords alone.
+			</p>
+
+			<h4>Security Keys</h4>
+			<ListKeys keys={ userKeys } />
+
+			<p className="wporg-2fa__submit-actions">
+				<Button variant="primary" onClick={ () => setStep( 'register' ) }>
+					Register New Key
+				</Button>
+
+				<Button
+					variant="secondary"
+					onClick={ () =>
+						confirm(
+							'Modal H4 Disable Security Keys? p Are you sure you want to disable Security Keys? Button Cancel Button Disable'
+						)
+					}
+				>
+					Disable Security Keys
+				</Button>
+			</p>
+		</>
+	);
+}
+
+/**
+ * Render the list of keys.
+ *
+ * @param props
+ * @param props.keys
+ */
+function ListKeys( { keys } ) {
+	return (
+		<ul>
+			{ keys.map( ( key ) => (
+				<li key={ key.id }>
+					{ key.name }
+
+					{ /* todo add onclick handler that pops up a <Modal> to confirm. maybe pass in from parent? */ }
+					<Button
+						variant="link"
+						data-id={ key.id }
+						aria-label="Delete"
+						onClick={ () =>
+							confirm(
+								'Modal H4 Remove Key? p Are you sure you want to remove the "" security key? Button Cancel Button Remove Key'
+							)
+						}
+					>
+						Delete
+					</Button>
+				</li>
+			) ) }
+		</ul>
+	);
+}
+
+/**
+ * Render the form to register new security keys.
+ *
+ * @param props
+ * @param props.registerClickHandler
+ */
+function RegisterKey( { registerClickHandler } ) {
+	return (
+		<form>
+			<TextControl label="Give the security key a name"></TextControl>
+
+			<div className="wporg-2fa__submit-actions">
+				<Button variant="primary" onClick={ registerClickHandler }>
+					Register Key
+				</Button>
+				<Button variant="secondary">Cancel</Button>
+			</div>
+		</form>
+	);
+}
+
+/**
+ * Render the "waiting for security key" component.
+ *
+ * This is what the user sees while their browser is handling the authentication process.
+ *
+ * @param props
+ * @param props.onRegisterSuccess
+ */
+function WaitingForSecurityKey( { onRegisterSuccess } ) {
+	// todo this is tmp placeholder to demonstrate the user activating their device
+	setTimeout( () => {
+		onRegisterSuccess();
+	}, 1500 );
+
+	return (
+		<>
+			<p>Waiting for security key. Connect and touch your security key to register it.</p>
+
+			<Spinner />
+		</>
+	);
+}
+
+/**
+ * Render the "Success" component.
+ *
+ * The user sees this once their security key has successfully been registered.
+ *
+ * @param props
+ * @param props.newKeyName
+ * @param props.setStep
+ */
+function Success( { newKeyName, setStep } ) {
+	// todo this may actually be similar to how it's done permanently
+	// need to sync this with the animation
+	setTimeout( () => {
+		setStep( 'manage' );
+	}, 2000 );
+
+	return (
+		<>
+			<p>Success! Your { newKeyName } is successfully registered.</p>
+
+			{ /* todo replace w/ custom animation */ }
+			<Icon icon={ check } />
+		</>
+	);
+}

--- a/settings/src/components/webauthn.scss
+++ b/settings/src/components/webauthn.scss
@@ -1,0 +1,3 @@
+.wporg-2fa__webauthn,
+.bbp-single-user .wporg-2fa__webauthn {
+}

--- a/settings/src/script.js
+++ b/settings/src/script.js
@@ -154,7 +154,10 @@ function Main( { userId } ) {
 				/>
 
 				<h3>
-					{ screen.replace( '-', ' ' ).replace( 'totp', 'Two-Factor Authentication' ) }
+					{ screen
+						.replace( '-', ' ' )
+						.replace( 'totp', 'Two-Factor App' )
+						.replace( 'webauthn', 'Two-Factor Security Key' ) }
 				</h3>
 			</CardHeader>
 

--- a/settings/src/script.js
+++ b/settings/src/script.js
@@ -21,6 +21,7 @@ import AccountStatus from './components/account-status';
 import Password from './components/password';
 import EmailAddress from './components/email-address';
 import TOTP from './components/totp';
+import WebAuthn from './components/webauthn';
 import BackupCodes from './components/backup-codes';
 import GlobalNotice from './components/global-notice';
 import RevalidateModal from './components/revalidate-modal';
@@ -71,8 +72,13 @@ function Main( { userId } ) {
 		'backup-codes': BackupCodes,
 	};
 
+	// TODO: Only enable WebAuthn UI in development, until it's finished.
+	if ( 'development' === process.env.NODE_ENV ) {
+		components.webauthn = WebAuthn;
+	}
+
 	// The screens where a recent two factor challenge is required.
-	const twoFactorRequiredScreens = [ 'totp', 'backup-codes' ];
+	const twoFactorRequiredScreens = [ 'webauthn', 'totp', 'backup-codes' ];
 
 	let initialScreen = currentUrl.searchParams.get( 'screen' );
 

--- a/settings/src/style.scss
+++ b/settings/src/style.scss
@@ -20,9 +20,13 @@ $alert-blue: #72aee6;
 .wp-block-wporg-two-factor-settings {
 	position: relative;
 
+	h3,
+	h4 {
+		clear: none;
+	}
+
 	h3 {
 		font-size: 14px;
-		clear: none;
 	}
 
 	/* Restore wporg-support styles that bbPress overrides */
@@ -37,7 +41,6 @@ $alert-blue: #72aee6;
 			font-family: "Open Sans", sans-serif;
 		}
 	}
-
 }
 
 .wporg-2fa__submit-actions {
@@ -67,6 +70,7 @@ $alert-blue: #72aee6;
 		margin: unset;
 		text-transform: capitalize;
 	}
+
 }
 
 .wporg-2fa__token {
@@ -95,6 +99,7 @@ $alert-blue: #72aee6;
 @import "components/account-status";
 @import "components/password";
 @import "components/email-address";
+@import "components/webauthn";
 @import "components/totp";
 @import "components/backup-codes";
 @import "components/setup-progress-bar";

--- a/settings/src/style.scss
+++ b/settings/src/style.scss
@@ -1,6 +1,9 @@
 @import '~@wordpress/base-styles/colors';
 @import '~@wordpress/base-styles/colors.native';
 
+// Gutenberg doesn't provide an "info" color, so this is taken from wp-admin's `.notice-info` class.
+$alert-blue: #72aee6;
+
 #main {
 	margin-bottom: 2rem;
 }


### PR DESCRIPTION
Fixes #87 

This lays the rough foundation from a code perspective, but doesn't attempt to refine the UI yet. That'll be in subsequent PRs, in order to keep each one small enough to review easily. The adds the UI behind a feature flag, so that users won't see it until it's finished.

This will also give us something tangible to mock up the the UI, since the WPCOM one isn't a direct translation. @jasmussen , what do you think?

WebAuthn and TOTP disabled:

<img width="780" alt="Screenshot 2023-05-24 at 3 05 59 PM" src="https://github.com/WordPress/wporg-two-factor/assets/484068/f5d26f7b-1268-4c09-9178-7b0620113d60">

WebAuthn disabled, TOTP enabled:

<img width="779" alt="Screenshot 2023-05-24 at 3 06 18 PM" src="https://github.com/WordPress/wporg-two-factor/assets/484068/92d84f77-9d43-4b88-b7d4-ec7c773f8dd2">

WebAuthn enabled, TOTP disabled:

<img width="780" alt="Screenshot 2023-05-24 at 3 06 34 PM" src="https://github.com/WordPress/wporg-two-factor/assets/484068/bb5861eb-3365-4add-ac5d-9903456845fc">

Initial WebAuthn screen:

<img width="775" alt="Screenshot 2023-05-24 at 3 18 11 PM" src="https://github.com/WordPress/wporg-two-factor/assets/484068/516ce633-c80d-4bc9-a359-24c2fd1b1fd6">

Register a key:

<img width="777" alt="Screenshot 2023-05-24 at 3 18 20 PM" src="https://github.com/WordPress/wporg-two-factor/assets/484068/17f58aaa-dee1-4644-9559-b934f2c79fff">

Complete key registration:

<img width="784" alt="Screenshot 2023-05-24 at 3 18 26 PM" src="https://github.com/WordPress/wporg-two-factor/assets/484068/2c972231-0c97-40fd-a7ac-fa70f4c6edae">


_Note: #141 was broken off of this, but not merged. it probably doesn't have anything worth bringing back over, this is just an FYI_