### PR TITLE
Encrypt TOTP keys

### DIFF
--- a/class-encrypted-totp-provider.php
+++ b/class-encrypted-totp-provider.php
@@ -21,8 +21,8 @@ class Encrypted_Totp_Provider extends Two_Factor_Totp {
 	 * @return bool True if the key was saved, false otherwise.
 	 */
 	public function set_user_totp_key( $user_id, $key ) {
-		if ( function_exists( 'wporg_encrypt' ) ) {
-			$key = wporg_encrypt( $key, 'two-factor' );
+		if ( function_exists( 'wporg_authenticated_encrypt' ) ) {
+			$key = wporg_authenticated_encrypt( $key, (string) $user_id, 'two-factor' );
 		}
 
 		return parent::set_user_totp_key( $user_id, (string) $key );
@@ -41,7 +41,7 @@ class Encrypted_Totp_Provider extends Two_Factor_Totp {
 
 		if ( $key && function_exists( 'wporg_is_encrypted' ) ) {
 			if ( wporg_is_encrypted( $key ) ) {
-				$key = (string) wporg_decrypt( $key, 'two-factor' );
+				$key = (string) wporg_authenticated_decrypt( $key, (string) $user_id, 'two-factor' );
 			} else {
 				// Upgrade the key to be encrypted.
 				$this->set_user_totp_key( $user_id, $key );

--- a/class-encrypted-totp-provider.php
+++ b/class-encrypted-totp-provider.php
@@ -21,8 +21,8 @@ class Encrypted_Totp_Provider extends Two_Factor_Totp {
 	 * @return bool True if the key was saved, false otherwise.
 	 */
 	public function set_user_totp_key( $user_id, $key ) {
-		if ( function_exists( 'wporg_authenticated_encrypt' ) ) {
-			$key = wporg_authenticated_encrypt( $key, (string) $user_id, 'two-factor' );
+		if ( function_exists( 'wporg_encrypt' ) ) {
+			$key = wporg_encrypt( $key, (string) $user_id, 'two-factor' );
 		}
 
 		return parent::set_user_totp_key( $user_id, (string) $key );
@@ -41,7 +41,7 @@ class Encrypted_Totp_Provider extends Two_Factor_Totp {
 
 		if ( $key && function_exists( 'wporg_is_encrypted' ) ) {
 			if ( wporg_is_encrypted( $key ) ) {
-				$key = (string) wporg_authenticated_decrypt( $key, (string) $user_id, 'two-factor' );
+				$key = (string) wporg_decrypt( $key, (string) $user_id, 'two-factor' );
 			} else {
 				// Upgrade the key to be encrypted.
 				$this->set_user_totp_key( $user_id, $key );

--- a/class-encrypted-totp-provider.php
+++ b/class-encrypted-totp-provider.php
@@ -1,0 +1,49 @@
+<?php
+namespace WordPressdotorg\Two_Factor;
+use Two_Factor_Totp;
+
+/**
+ * Extends the default Two_Factor_Totp class to encrypt the TOTP key.
+ */
+class Encrypted_Totp_Provider extends Two_Factor_Totp {
+	/**
+	 * Use the parent class as the "key" in the Two Factor UI.
+	 */
+	public function get_key() {
+		return parent::class;
+	}
+
+	/**
+	 * When saving the key, encrypt it first.
+	 *
+	 * @param int    $user_id User ID.
+	 * @param string $key     TOTP key.
+	 * @return bool True if the key was saved, false otherwise.
+	 */
+	public function set_user_totp_key( $user_id, $key ) {
+		if ( function_exists( 'wporg_encrypt' ) ) {
+			$key = wporg_encrypt( $key, 'two-factor' );
+		}
+
+		return parent::set_user_totp_key( $user_id, $key );
+	}
+
+	/**
+	 * When retrieving the key, decrypt it first.
+	 *
+	 * @param int $user_id User ID.
+	 * @return string|false TOTP key, or false if not set.
+	 */
+	public function get_user_totp_key( $user_id ) {
+		$key = parent::get_user_totp_key( $user_id );
+		if ( ! $key ) {
+			return $key;
+		}
+
+		if ( function_exists( 'wporg_maybe_decrypt' ) ) {
+			$key = wporg_maybe_decrypt( $key, 'two-factor' );
+		}
+
+		return $key;
+	}
+}

--- a/class-encrypted-totp-provider.php
+++ b/class-encrypted-totp-provider.php
@@ -25,23 +25,27 @@ class Encrypted_Totp_Provider extends Two_Factor_Totp {
 			$key = wporg_encrypt( $key, 'two-factor' );
 		}
 
-		return parent::set_user_totp_key( $user_id, $key );
+		return parent::set_user_totp_key( $user_id, (string) $key );
 	}
 
 	/**
 	 * When retrieving the key, decrypt it first.
+	 *
+	 * If the key isn't currently stored encrypted, it's upgraded to encrypted status.
 	 *
 	 * @param int $user_id User ID.
 	 * @return string|false TOTP key, or false if not set.
 	 */
 	public function get_user_totp_key( $user_id ) {
 		$key = parent::get_user_totp_key( $user_id );
-		if ( ! $key ) {
-			return $key;
-		}
 
-		if ( function_exists( 'wporg_maybe_decrypt' ) ) {
-			$key = wporg_maybe_decrypt( $key, 'two-factor' );
+		if ( $key && function_exists( 'wporg_is_encrypted' ) ) {
+			if ( wporg_is_encrypted( $key ) ) {
+				$key = (string) wporg_decrypt( $key, 'two-factor' );
+			} else {
+				// Upgrade the key to be encrypted.
+				$this->set_user_totp_key( $user_id, $key );
+			}
 		}
 
 		return $key;

--- a/tests/test-wporg-two-factor.php
+++ b/tests/test-wporg-two-factor.php
@@ -1,6 +1,7 @@
 <?php
 
 use function WordPressdotorg\Two_Factor\{ user_requires_2fa };
+use function WordPressdotorg\MU_Plugins\Encryption\{ generate_encryption_key };
 
 defined( 'WPINC' ) || die();
 
@@ -19,6 +20,17 @@ class Test_WPorg_Two_Factor extends WP_UnitTestCase {
 			'user_login' => 'regular_user',
 			'role'       => 'contributor',
 		) );
+
+		// Generate an encryption key for testing with.
+		if ( ! function_exists( 'wporg_encryption_keys' ) ) {
+			function wporg_encryption_keys() {
+				static $keys = null;
+
+				return $keys ?? $keys = [
+					'two-factor' => generate_encryption_key(),
+				];
+			}
+		}
 	}
 
 	/**

--- a/tests/test-wporg-two-factor.php
+++ b/tests/test-wporg-two-factor.php
@@ -230,10 +230,14 @@ class Test_WPorg_Two_Factor extends WP_UnitTestCase {
 		$enabled       = Two_Factor_Core::enable_provider_for_user( self::$regular_user->ID, 'Two_Factor_Totp' );
 		$this->assertTrue( $enabled );
 
-		// Validate that the TOTP key was stored in an encrypted form.
-		$totp_key       = $totp_provider->get_user_totp_key( self::$regular_user->ID );
-		$totp_user_meta = get_user_meta( self::$regular_user->ID, $totp_provider::SECRET_META_KEY, true );
-		$this->assertNotSame( $totp_key, $totp_user_meta );
+		// Validate that the TOTP key was stored in an encrypted form, if encryption methods are available.
+		// Pending https://github.com/WordPress/wporg-mu-plugins/pull/390 merge.
+		if ( function_exists( 'wporg_is_encrypted' ) ) {
+			$totp_key       = $totp_provider->get_user_totp_key( self::$regular_user->ID );
+			$totp_user_meta = get_user_meta( self::$regular_user->ID, $totp_provider::SECRET_META_KEY, true );
+			$this->assertNotSame( $totp_key, $totp_user_meta );
+			$this->assertTrue( wporg_is_encrypted( $totp_user_meta ) );
+		}
 
 		// Validate that TOTP is now the primary provider.
 		$provider       = Two_Factor_Core::get_primary_provider_for_user( self::$regular_user->ID );

--- a/tests/test-wporg-two-factor.php
+++ b/tests/test-wporg-two-factor.php
@@ -230,14 +230,10 @@ class Test_WPorg_Two_Factor extends WP_UnitTestCase {
 		$enabled       = Two_Factor_Core::enable_provider_for_user( self::$regular_user->ID, 'Two_Factor_Totp' );
 		$this->assertTrue( $enabled );
 
-		// Validate that the TOTP key was stored in an encrypted form, if encryption methods are available.
-		// Pending https://github.com/WordPress/wporg-mu-plugins/pull/390 merge.
-		if ( function_exists( 'wporg_is_encrypted' ) ) {
-			$totp_key       = $totp_provider->get_user_totp_key( self::$regular_user->ID );
-			$totp_user_meta = get_user_meta( self::$regular_user->ID, $totp_provider::SECRET_META_KEY, true );
-			$this->assertNotSame( $totp_key, $totp_user_meta );
-			$this->assertTrue( wporg_is_encrypted( $totp_user_meta ) );
-		}
+		// Validate that the TOTP key was stored in an encrypted form.
+		$totp_key       = $totp_provider->get_user_totp_key( self::$regular_user->ID );
+		$totp_user_meta = get_user_meta( self::$regular_user->ID, $totp_provider::SECRET_META_KEY, true );
+		$this->assertNotSame( $totp_key, $totp_user_meta );
 
 		// Validate that TOTP is now the primary provider.
 		$provider       = Two_Factor_Core::get_primary_provider_for_user( self::$regular_user->ID );

--- a/tests/test-wporg-two-factor.php
+++ b/tests/test-wporg-two-factor.php
@@ -65,7 +65,9 @@ class Test_WPorg_Two_Factor extends WP_UnitTestCase {
 		// This should start counting at one instead of zero, to match `Two_Factor_Core`.
 		update_user_meta( $user_id, Two_Factor_Core::ENABLED_PROVIDERS_USER_META_KEY, array( 1 => 'Two_Factor_Totp' ) );
 		update_user_meta( $user_id, Two_Factor_Core::PROVIDER_USER_META_KEY, 'Two_Factor_Totp' );
-		update_user_meta( $user_id, Two_Factor_Totp::SECRET_META_KEY, 'foo bar bax quiz' );
+
+		$totp_provider = Two_Factor_Core::get_providers()['Two_Factor_Totp'];
+		$totp_provider->set_user_totp_key( $user_id, $totp_provider->generate_key() );
 
 		$this->assertTrue( Two_Factor_Core::is_user_using_two_factor( $user_id ) );
 	}

--- a/tests/test-wporg-two-factor.php
+++ b/tests/test-wporg-two-factor.php
@@ -229,7 +229,7 @@ class Test_WPorg_Two_Factor extends WP_UnitTestCase {
 		$totp_provider->set_user_totp_key( self::$regular_user->ID, Two_Factor_Totp::generate_key() );
 		$enabled = Two_Factor_Core::enable_provider_for_user( self::$regular_user->ID, 'Two_Factor_Totp' );
 
-		$expected = 'Two_Factor_Totp';
+		$expected = 'WordPressdotorg\Two_Factor\Encrypted_Totp_Provider';
 		$actual   = get_class( Two_Factor_Core::get_primary_provider_for_user( self::$regular_user->ID ) );
 		$this->assertTrue( $enabled );
 		$this->assertSame( $expected, $actual );

--- a/tests/test-wporg-two-factor.php
+++ b/tests/test-wporg-two-factor.php
@@ -229,10 +229,17 @@ class Test_WPorg_Two_Factor extends WP_UnitTestCase {
 		$totp_provider->set_user_totp_key( self::$regular_user->ID, Two_Factor_Totp::generate_key() );
 		$enabled = Two_Factor_Core::enable_provider_for_user( self::$regular_user->ID, 'Two_Factor_Totp' );
 
-		$expected = 'WordPressdotorg\Two_Factor\Encrypted_Totp_Provider';
-		$actual   = get_class( Two_Factor_Core::get_primary_provider_for_user( self::$regular_user->ID ) );
 		$this->assertTrue( $enabled );
-		$this->assertSame( $expected, $actual );
+
+		$provider = Two_Factor_Core::get_primary_provider_for_user( self::$regular_user->ID );
+
+		$expected_class = 'WordPressdotorg\Two_Factor\Encrypted_Totp_Provider';
+		$actual_class   = get_class( $provider );
+		$this->assertSame( $expected_class, $actual_class );
+
+		$expected_key = 'Two_Factor_Totp';
+		$actual_key   = $provider->get_key();
+		$this->assertSame( $expected_key, $provider->get_key() );
 
 		// Validate that Backup Codes are now available as secondary.
 		$expected = [ 'Two_Factor_Backup_Codes', 'Two_Factor_Totp' ];

--- a/wporg-two-factor.php
+++ b/wporg-two-factor.php
@@ -244,6 +244,15 @@ function get_edit_account_url() : string {
 	return $url;
 }
 
+/*
+ * Switch out the TOTP provider for one that encrypts the TOTP key.
+ */
+add_filter( 'two_factor_provider_classname_Two_Factor_Totp', function( string $provider ) : string {
+	require_once __DIR__ . '/class-encrypted-totp-provider.php';
+
+	return __NAMESPACE__ . '\Encrypted_Totp_Provider';
+} );
+
 // Temp fix for TOTP QR code being broken, see: https://meta.trac.wordpress.org/timeline?from=2023-02-21T04%3A40%3A07Z&precision=second.
 // Hotfix for https://github.com/WordPress/gutenberg/pull/48268
 add_filter( 'block_type_metadata', function( $metadata ) {


### PR DESCRIPTION
Fixes #101

Depends upon https://github.com/WordPress/wporg-mu-plugins/pull/390
Made possible by https://github.com/WordPress/two-factor/pull/546

NOTE: if you test this on a sandbox (and then remove this), you will be unable to login with TOTP again without deactivating TOTP.

Testing Instructions:
 - Make sure you're running a version of `two-factor` with https://github.com/WordPress/two-factor/pull/546 merged
 - Define `WPORG_ENCRYPTION_KEY` and optionally `WPORG_TWO_FACTOR_ENCRYPTION_KEY`, with a value from `\WordPressdotorg\MU_Plugins\Encryption\generate_encryption_key()`
 - View `_two_factor_totp_key` value. Validate that it appears plaintext.
 - Login with TOTP.
 - View `_two_factor_totp_key` value. Validate that it appears to be encrypted (Long, and prefixed with `$t1$`).
 - Deactivate TOTP.
 - Setup TOTP.
 - Validate everything worked as expected.

TODO:
 - [x] Unit Tests.
 - [x] https://github.com/WordPress/wporg-mu-plugins/pull/390 (This is not required prior to this merging, but is required for it to actually encrypt)
 - [x] Test once 390 is merged
 - [x] Test on production sandbox, verify TOTPs are upgraded upon login.