### PR TITLE
Make users profile page look less tight

### DIFF
--- a/settings/src/script.js
+++ b/settings/src/script.js
@@ -141,7 +141,7 @@ function Main( { userId } ) {
 						<h3>{ screen.replace( '-', ' ' ).replace( 'totp', 'Two-Factor Authentication' ) }</h3>
 				</CardHeader>
 
-				<CardBody className={ 'wporg-2fa__screen-wrapper wporg-2fa__' + screen }>
+				<CardBody className={ 'wporg-2fa__' + screen }>
 					<CurrentScreen />
 				</CardBody>
 			</Card>

--- a/settings/src/style.scss
+++ b/settings/src/style.scss
@@ -53,11 +53,6 @@
 	letter-spacing: .3em;
 }
 
-.wporg-2fa__screen-wrapper {
-	min-height: 665px !important;
-    height: unset !important;
-}
-
 .components-notice {
 	margin-left: 0;
 	margin-right: 0;

--- a/settings/src/style.scss
+++ b/settings/src/style.scss
@@ -1,6 +1,10 @@
 @import '~@wordpress/base-styles/colors';
 @import '~@wordpress/base-styles/colors.native';
 
+#main {
+	margin-bottom: 2rem;
+}
+
 .wp-block-wporg-two-factor-settings {
 	position: relative;
 


### PR DESCRIPTION
Fixes #102 

This PR
1. Removes height restriction that makes the layout go off.
2. Add `margin-bottom: 2em` to the profile page for a less crowded look.
   a. `2em` comes from the `margin-top` value set in `#main`.

## Screencast

https://user-images.githubusercontent.com/18050944/232853625-f677a9bf-22d5-4422-8050-069092eb6d07.mp4

