### PR TITLE
Update notice on email address view.

### DIFF
--- a/settings/src/components/email-address.js
+++ b/settings/src/components/email-address.js
@@ -4,6 +4,10 @@
  */
 import { Button, TextControl, Notice, Spinner } from '@wordpress/components';
 import { useCallback, useContext, useState } from '@wordpress/element';
+import {
+	Icon,
+	cancelCircleFilled,
+} from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -92,7 +96,7 @@ export default function EmailAddress() {
 				onChange={ (email) => edit( { email } ) }
 			/>
 
-			{ emailError && <p className="email-error">{ emailError }</p> }
+			{ emailError && <Notice status="error" isDismissible={ false }><Icon icon={ cancelCircleFilled } />{ emailError }</Notice> }
 
 			<p>
 				<Button

--- a/settings/src/components/email-address.scss
+++ b/settings/src/components/email-address.scss
@@ -7,8 +7,4 @@
 			margin: initial; /* wporg-support adds top padding to <p> causing button alignment issues. */
 		}
 	}
-
-	.email-error {
-		color: $alert-red;
-	}
 }


### PR DESCRIPTION
Fixes: #116 

This PR aligns the notice states between the email and the password views.

| Before | After | 
| --- | --- | 
| <img width="776" alt="Screenshot 2023-04-20 at 11 27 08 AM" src="https://user-images.githubusercontent.com/1657336/233241958-08d46a8c-2c41-4097-a509-51aa271d2c16.png"> | <img width="785" alt="Screenshot 2023-04-20 at 11 26 57 AM" src="https://user-images.githubusercontent.com/1657336/233241965-08520949-5449-4910-aa4a-a6ecbf83532c.png"> |


