### PR TITLE
Update the useCallback to watch edits.

### DIFF
--- a/settings/src/script.js
+++ b/settings/src/script.js
@@ -109,7 +109,7 @@ function Main( { userId } ) {
 
 		setGlobalNotice( '' );
 		setScreen( screen );
-	}, [] );
+	}, [ hasEdits ] );
 
 	if ( ! hasResolved ) {
 		return <Spinner />;


### PR DESCRIPTION
Related to #117 
Fixes #120 

This PR updates `clickScreenLink`'s, `useCallback` to watch for userEdits to restore state clearing when users click the back button. This also fixes #120 as the `hasEdits` state is clean on load.

This doesn't close #117 as the password view still _dirty_ regardless of the navigation back and forth.

### How to test
1. Edit email address, change it to something, don't save
2. Click "back"
3. Go back to that view, notice the email is reset
4. Change it again
5. Click "back"
6. Click to update your password, notice the view is working as expected.