### PR TITLE
A11y audit

### DIFF
--- a/settings/settings.php
+++ b/settings/settings.php
@@ -44,7 +44,7 @@ function render_custom_ui() : void {
 		return;
 	}
 
-	echo '<div class="notice notice-info notice-alt"><p>This interface and functionality is currently a <em>beta release</em>, while it is currently operational it\'s not yet officially released. Please report any issues you encounter to <a href="https://github.com/WordPress/wporg-two-factor/issues" data-content="notice-info-link">WordPress/wporg-two-factor on GitHub</a>.</p></div>';
+	echo '<div class="notice notice-info notice-alt"><p>This interface and functionality is currently a <em>beta release</em>, while it is currently operational it\'s not yet officially released. Please report any issues you encounter to <a href="https://github.com/WordPress/wporg-two-factor/issues">WordPress/wporg-two-factor on GitHub</a>.</p></div>';
 
 	$user_id    = bbp_get_displayed_user_id();
 	$json_attrs = json_encode( [ 'userId' => $user_id ] );

--- a/settings/settings.php
+++ b/settings/settings.php
@@ -44,7 +44,7 @@ function render_custom_ui() : void {
 		return;
 	}
 
-	echo '<div class="notice notice-info notice-alt"><p>This interface and functionality is currently a <em>beta release</em>, while it is currently operational it\'s not yet officially released. Please report any issues you encounter to <a href="https://github.com/WordPress/wporg-two-factor/issues">WordPress/wporg-two-factor on GitHub</a>.</p></div>';
+	echo '<div class="notice notice-info notice-alt"><p>This interface and functionality is currently a <em>beta release</em>, while it is currently operational it\'s not yet officially released. Please report any issues you encounter to <a href="https://github.com/WordPress/wporg-two-factor/issues" data-content="notice-info-link">WordPress/wporg-two-factor on GitHub</a>.</p></div>';
 
 	$user_id    = bbp_get_displayed_user_id();
 	$json_attrs = json_encode( [ 'userId' => $user_id ] );

--- a/settings/src/components/account-status.js
+++ b/settings/src/components/account-status.js
@@ -73,7 +73,7 @@ function SettingStatusCard( { screen, status, headerText, bodyText } ) {
 				anchorText={
 					<CardBody>
 						<StatusIcon status={ status } />
-						<h3>{ headerText }</h3>
+						<h3 aria-label={headerText + '.'}>{ headerText }</h3>
 						<p>{ bodyText }</p>
 						<Icon icon={ chevronRight } size={ 26 } className="wporg-2fa__status-card-open" />
 					</CardBody>

--- a/settings/src/components/account-status.js
+++ b/settings/src/components/account-status.js
@@ -73,7 +73,7 @@ function SettingStatusCard( { screen, status, headerText, bodyText } ) {
 				anchorText={
 					<CardBody>
 						<StatusIcon status={ status } />
-						<h3 aria-label={headerText + '.'}>{ headerText }</h3>
+						<h3 aria-label={"Click to enter the " + headerText + ' setting page.'}>{ headerText }</h3>
 						<p>{ bodyText }</p>
 						<Icon icon={ chevronRight } size={ 26 } className="wporg-2fa__status-card-open" />
 					</CardBody>

--- a/settings/src/components/email-address.js
+++ b/settings/src/components/email-address.js
@@ -91,7 +91,7 @@ export default function EmailAddress() {
 				help="We will send you a verification email before updating your email address."
 				label="Your email address"
 				size="62"
-				placeholder="my-email-address@example.org"
+				placeholder="Enter email address..."
 				value={ editedRecord.email ?? record.email }
 				onChange={ (email) => edit( { email } ) }
 			/>

--- a/settings/src/components/password.js
+++ b/settings/src/components/password.js
@@ -128,7 +128,7 @@ export default function Password() {
 					label="New Password"
 					size="62"
 					value={ userRecord.editedRecord.password ?? '' }
-					placeholder="Q1jtBPRmROv51KOtbZ5aIKrc"
+					placeholder="Enter New Password..."
 					onChange={ handlePasswordChange }
 				/>
 				<Button

--- a/settings/src/components/screen-link.js
+++ b/settings/src/components/screen-link.js
@@ -8,7 +8,7 @@ import { useContext } from '@wordpress/element';
  */
 import { GlobalContext } from '../script';
 
-export default function ScreenLink( { screen, anchorText, buttonStyle = false } ) {
+export default function ScreenLink( { screen, anchorText, buttonStyle = false, ariaLabel } ) {
 	const { clickScreenLink } = useContext( GlobalContext );
 	const classes = [];
 	let screenUrl = new URL( document.location.href );
@@ -28,6 +28,7 @@ export default function ScreenLink( { screen, anchorText, buttonStyle = false } 
 			href={ screenUrl.href }
 			onClick={ ( event ) => clickScreenLink( event, screen ) }
 			className={ classes.join( ' ' ) }
+			aria-label={ ariaLabel }
 		>
 			{ anchorText }
 		</a>

--- a/settings/src/components/totp.js
+++ b/settings/src/components/totp.js
@@ -129,7 +129,7 @@ function SetupMethod( { setupMethod, setSetupMethod, qrCodeUrl, secretKey } ) {
 					{ ! qrCodeUrl && 'Loading...' }
 
 					{ qrCodeUrl &&
-						<a href={ qrCodeUrl } aria-label="Scan QR code">
+						<a href={ qrCodeUrl } aria-label="QR code to scan">
 							<RawHTML>
 								{ createQrCode( qrCodeUrl ) }
 							</RawHTML>
@@ -212,10 +212,10 @@ function SetupForm( { handleEnable, qrCodeUrl, secretKey, inputs, setInputs, err
 				<AutoTabbingInput inputs={inputs} setInputs={setInputs} error={error} onComplete={handleComplete}/>
 
 				<div className="wporg-2fa__submit-btn-container">
-					<Button variant="secondary" onClick={ handleClearClick }>
+					<Button variant="secondary" onClick={ handleClearClick } aria-label="Clear all inputs">
 						Clear
 					</Button>
-					<Button type="submit" variant="primary" disabled={ ! canSubmit }>
+					<Button type="submit" variant="primary" disabled={ ! canSubmit } aria-label="Submit input digits">
 						Enable
 					</Button>
 				</div>

--- a/settings/src/script.js
+++ b/settings/src/script.js
@@ -129,6 +129,7 @@ function Main( { userId } ) {
 				<CardHeader className="wporg-2fa__navigation" size="xSmall">
 						<ScreenLink
 							screen="account-status"
+							ariaLabel="Back to the account status page"
 							anchorText={
 								<>
 									<Icon icon={ chevronLeft } />

--- a/settings/src/style.scss
+++ b/settings/src/style.scss
@@ -5,8 +5,13 @@
 	margin-bottom: 2rem;
 }
 
-a[data-content*="notice-info-link"] {
-	text-decoration: underline;
+#bbp-your-profile {
+	.components-notice,
+	.notice {
+		a {
+			text-decoration: underline;
+		}
+	}
 }
 
 .wp-block-wporg-two-factor-settings {

--- a/settings/src/style.scss
+++ b/settings/src/style.scss
@@ -5,6 +5,10 @@
 	margin-bottom: 2rem;
 }
 
+a[data-content*="notice-info-link"] {
+	text-decoration: underline;
+}
+
 .wp-block-wporg-two-factor-settings {
 	position: relative;
 


### PR DESCRIPTION
Fixes #110 

This PR tested items listed in #110 and did changes accordingly.

For `HTML5 landmark elements are used to improve navigation`, originally, I was trying to add `role="list"` or `role="region"` to the setting list in the `Main` section to improve screen reader navigation, but I found that VoiceOver couldn't detect either of them. Among the other roles, though it can detect `role="article"`, it doesn't seem to be a very suitable role. So I didn't make any changes to that item.

![Screen Shot 2023-04-20 at 10 00 05 PM](https://user-images.githubusercontent.com/18050944/233392943-861848b7-b0a6-465e-9f23-c161de80896d.png)

![Screen Shot 2023-04-20 at 9 59 35 PM](https://user-images.githubusercontent.com/18050944/233392936-952af893-a668-4872-bed6-e176594c1f45.png)
