### PR TITLE
Show password errors on submit to improve UX

### DIFF
--- a/settings/src/components/password.js
+++ b/settings/src/components/password.js
@@ -165,11 +165,7 @@ export default function Password() {
 			<p>
 				<Button
 					isPrimary
-					disabled={
-						passwordStrong && ! userRecord.isSaving
-							? ''
-							: 'disabled'
-					}
+					disabled={ ! userRecord.editedRecord.password }
 					type="submit"
 				>
 					{ userRecord.isSaving ? 'Saving...' : 'Save password' }

--- a/settings/src/components/password.js
+++ b/settings/src/components/password.js
@@ -154,7 +154,7 @@ export default function Password() {
 				</Notice>
 			) }
 
-			{ userRecord.hasEdits && ! passwordStrong && (
+			{ userRecord.hasEdits && userRecord.editedRecord.password && ! passwordStrong && (
 				<Notice status="error" isDismissible={ false }>
 					<Icon icon={ cancelCircleFilled } />
 					That password is too easy to compromise. Please make it

--- a/settings/src/components/password.js
+++ b/settings/src/components/password.js
@@ -38,6 +38,7 @@ import { GlobalContext } from '../script';
 export default function Password() {
 	const { setGlobalNotice, userRecord } = useContext( GlobalContext );
 	const [ inputType, setInputType ] = useState( 'password' );
+	const [ hasAttemptedSave, setHasAttemptedSave ] = useState( false );
 	let passwordStrong = true; // Saved passwords have already passed the test.
 
 	if ( userRecord.hasEdits ) {
@@ -68,6 +69,8 @@ export default function Password() {
 	const handleFormSubmit = useCallback(
 		async ( event ) => {
 			event.preventDefault();
+
+			setHasAttemptedSave( true );
 
 			if ( ! passwordStrong || userRecord.isSaving ) {
 				return;
@@ -154,7 +157,7 @@ export default function Password() {
 				</Notice>
 			) }
 
-			{ userRecord.hasEdits && userRecord.editedRecord.password && ! passwordStrong && (
+			{ userRecord.hasEdits && userRecord.editedRecord.password && hasAttemptedSave && ! passwordStrong && (
 				<Notice status="error" isDismissible={ false }>
 					<Icon icon={ cancelCircleFilled } />
 					That password is too easy to compromise. Please make it


### PR DESCRIPTION
Fixes #118

This only shows a password error after the user has tried to submit the form. Before that, showing it can be annoying because they know it's not valid until they've finished trying. After they've attempted to save, though, it can be helpful to get instant acknowledgement when the password is strong enough.

This doesn't change behavior of "is strong enough" notice at all. That seems good to me, but I don't feel strongly.

![password ux](https://user-images.githubusercontent.com/484068/233751353-fb78312b-0b4f-47dd-ba1a-73b402fb897a.gif)
