### PR TITLE
Fork upstream WebAuthn provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ WordPress.org-specific customizations for the Two Factor plugin
 		return in_array( $user->user_login, $GLOBALS['supes'], true );
 	}
 	```
-1. Install and build the `wporg-mu-plugins` repository.
+1. `git clone https://github.com/WordPress/wporg-mu-plugins.git --branch build wp-content/mu-plugins/pub`
 1. Add this code to your `wp-content/mu-plugins/0-sandbox.php`:
 	```php
 	require_once WPMU_PLUGIN_DIR. '/wporg-mu-plugins/mu-plugins/loader.php';

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -30,6 +30,7 @@
 	  -->
 	<coverage processUncoveredFiles="false">
 		<include>
+			<directory>./providers</directory>
 			<file>wporg-two-factor.php</file>
 			<file>class-encrypted-totp-provider.php</file>
 			<file>settings/settings.php</file>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -31,6 +31,7 @@
 	<coverage processUncoveredFiles="false">
 		<include>
 			<file>wporg-two-factor.php</file>
+			<file>class-encrypted-totp-provider.php</file>
 			<file>settings/settings.php</file>
 			<file>settings/rest-api.php</file>
 		</include>

--- a/providers/webauthn/class-two-factor-webauthn.php
+++ b/providers/webauthn/class-two-factor-webauthn.php
@@ -1,0 +1,642 @@
+<?php
+/**
+ * Class for creating WebAuthn token
+ *
+ * @package Two_Factor
+ */
+
+/**
+ * Class Two_Factor_WebAuthn.
+ */
+class Two_Factor_WebAuthn extends Two_Factor_Provider {
+
+	/**
+	 * The user meta login key.
+	 *
+	 * @type string
+	 */
+	const LOGIN_USERMETA = '_two_factor_webauthn_login';
+
+	/**
+	 * Handling WebAuthn requests and responses.
+	 *
+	 * @var WebAuthnHandler
+	 */
+	protected $webauthn;
+
+	/**
+	 * Holding a users keys.
+	 *
+	 * @var WebAuthnKeyStore
+	 */
+	protected $key_store;
+
+	/**
+	 * Ensures only one instance of this class exists in memory at any one time.
+	 *
+	 * @return \Two_Factor_WebAuthn
+	 */
+	public static function get_instance() {
+		static $instance;
+
+		if ( ! isset( $instance ) ) {
+			$instance = new self();
+		}
+
+		return $instance;
+	}
+
+	/**
+	 * Class constructor.
+	 */
+	protected function __construct() {
+
+		require_once __DIR__ . '/includes/class-webauthn-handler.php';
+		require_once __DIR__ . '/includes/class-cbor-decoder.php';
+		require_once __DIR__ . '/includes/class-webauthn-keystore.php';
+
+		$this->webauthn = new WebAuthnHandler( $this->get_app_id() );
+
+		$this->key_store = WebAuthnKeyStore::instance();
+
+		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'register_assets' ) );
+		add_action( 'login_enqueue_scripts', array( __CLASS__, 'register_assets' ) );
+
+		add_action( 'wp_ajax_webauthn-register', array( $this, 'ajax_register' ) );
+		add_action( 'wp_ajax_webauthn-edit-key', array( $this, 'ajax_edit_key' ) );
+		add_action( 'wp_ajax_webauthn-delete-key', array( $this, 'ajax_delete_key' ) );
+		add_action( 'wp_ajax_webauthn-test-key', array( $this, 'ajax_test_key' ) );
+
+		add_action( 'two_factor_user_options_' . __CLASS__, array( $this, 'user_options' ) );
+
+		parent::__construct();
+
+	}
+
+	public static function register_assets() {
+		wp_register_script(
+			'webauthn-login',
+			plugins_url( 'webauthn-login.js', __FILE__ ),
+			array( 'jquery' ),
+			filemtime( __DIR__ . '/webauthn-login.js' ),
+			true
+		);
+
+		wp_register_script(
+			'webauthn-admin',
+			plugins_url( 'webauthn-admin.js', __FILE__ ),
+			array( 'jquery' ),
+			filemtime( __DIR__ . '/webauthn-admin.js' ),
+			true
+		);
+
+		wp_register_style(
+			'webauthn-admin',
+			plugins_url( 'webauthn-admin.css', __FILE__ ),
+			array(),
+			filemtime( __DIR__ . '/webauthn-admin.css' )
+		);
+
+		wp_register_style(
+			'webauthn-login',
+			plugins_url( 'webauthn-login.css', __FILE__ ),
+			array(),
+			filemtime( __DIR__ . '/webauthn-login.css' )
+		);
+	}
+
+	/**
+	 * Return the U2F AppId. WebAuthn requires the AppID
+	 * to be the current domain or a suffix of it.
+	 *
+	 * @return string AppID FQDN
+	 */
+	public function get_app_id() {
+
+		$url_parts = wp_parse_url( network_site_url() );
+
+		$app_id = $url_parts['host'];
+
+		if ( ! empty( $url_parts['port'] ) ) {
+			$app_id = sprintf( '%s:%d', $app_id, $url_parts['port'] );
+		}
+
+		/**
+		 * Filter the WebAuthn App ID.
+		 *
+		 * In order for this to work, the App-ID has to be either the current
+		 * (sub-)domain or a suffix of it.
+		 *
+		 * @param string $app_id Domain name acting as relying party ID.
+		 */
+		return apply_filters( 'two_factor_webauthn_app_id', $app_id );
+
+	}
+
+
+	/**
+	 * Returns the name of the provider.
+	 *
+	 * @return string
+	 */
+	public function get_label() {
+		return _x( 'Web Authentication (FIDO2)', 'Provider Label', 'two-factor' );
+	}
+
+	/**
+	 * Prints the form that prompts the user to authenticate.
+	 *
+	 * @param WP_User $user WP_User object of the logged-in user.
+	 * @return null
+	 */
+	public function authentication_page( $user ) {
+
+		wp_enqueue_style( 'webauthn-login' );
+
+		require_once ABSPATH . '/wp-admin/includes/template.php';
+
+		// WebAuthn  doesn't work without HTTPS.
+		if ( ! is_ssl() ) {
+			?>
+			<p><?php esc_html_e( 'Web Authentication requires an HTTPS connection. Please use an alternative 2nd factor method.', 'two-factor' ); ?></p>
+			<?php
+
+			return;
+		}
+
+		try {
+
+			$keys = $this->key_store->get_keys( $user->ID );
+
+			$auth_opts = $this->webauthn->prepareAuthenticate( $keys );
+
+			update_user_meta( $user->ID, self::LOGIN_USERMETA, 1 );
+		} catch ( Exception $e ) {
+			?>
+			<p><?php esc_html_e( 'An error occurred while creating authentication data.', 'two-factor' ); ?></p>
+			<?php
+			return null;
+		}
+
+		wp_localize_script(
+			'webauthn-login',
+			'webauthnL10n',
+			array(
+				'action'   => 'webauthn-login',
+				'payload'  => $auth_opts,
+				'_wpnonce' => wp_create_nonce( 'webauthn-login' ),
+			)
+		);
+
+		wp_enqueue_script( 'webauthn-login' );
+
+		?>
+		<p><?php esc_html_e( 'Please authenticate yourself.', 'two-factor' ); ?></p>
+		<input type="hidden" name="webauthn_response" id="webauthn_response" />
+
+		<div class="webauthn-retry">
+			<p>
+				<a href="#" class="webauthn-retry-link button-primary">
+					<?php esc_html_e( 'Connect to Authenticator', 'two-factor' ); ?>
+				</a>
+			</p>
+		</div>
+		<div class="webauthn-unsupported">
+			<p>
+				<span class="dashicons dashicons-warning"></span>
+				<?php esc_html_e( 'Your Browser does not support WebAuthn.', 'two-factor' ); ?>
+				<?php esc_html_e( 'Please use a backup method.', 'two-factor' ); ?>
+			</p>
+		</div>
+		<?php
+	}
+
+
+
+	/**
+	 * Validates the users input token.
+	 *
+	 * @param WP_User $user WP_User object of the logged-in user.
+	 * @return boolean
+	 */
+	public function validate_authentication( $user ) {
+
+		$credential = json_decode( wp_unslash( $_POST['webauthn_response'] ) ); // PHPCS:ignore WordPress.Security.NonceVerification.Missing
+
+		if ( ! is_object( $credential ) ) {
+			return false;
+		}
+
+		$keys = $this->key_store->get_keys( $user->ID );
+
+		$auth = $this->webauthn->authenticate( $credential, $keys );
+
+		if ( false === $auth ) {
+			return false;
+		}
+		$auth->last_used = time();
+		$this->key_store->save_key( $user->ID, $auth, $auth->md5id );
+		delete_user_meta( $user->ID, self::LOGIN_USERMETA );
+
+		return true;
+	}
+
+	/**
+	 * Whether this Two Factor provider is configured and available for the user specified.
+	 *
+	 * @param WP_User $user WP_User object of the logged-in user.
+	 * @return boolean
+	 */
+	public function is_available_for_user( $user ) {
+		// only works for currently logged in user.
+		return (bool) count( $this->key_store->get_keys( $user->ID ) );
+	}
+
+	/**
+	 * Inserts markup at the end of the user profile field for this provider.
+	 *
+	 * @param WP_User $user WP_User object of the logged-in user.
+	 */
+	public function user_options( $user ) {
+
+		wp_enqueue_script( 'webauthn-admin' );
+		wp_enqueue_style( 'webauthn-admin' );
+
+		$challenge = $this->webauthn->prepareRegister( $user->display_name, $user->user_login );
+
+		$create_data = array(
+			'action'   => 'webauthn-register',
+			'payload'  => $challenge,
+			'userId'   => $user->ID,
+			'_wpnonce' => wp_create_nonce( 'webauthn-register' ),
+		);
+
+		$keys = $this->key_store->get_keys( $user->ID );
+
+		?>
+		<p>
+			<?php esc_html_e( 'Requires an HTTPS connection. You can configure hardware authenticators like an USB token or your current device with the button below.', 'two-factor' ); ?>
+		</p>
+
+		<div class="webauthn-supported webauth-register">
+			<button class="button-secondary" id="webauthn-register-key" data-create-options="<?php echo esc_attr( wp_json_encode( $create_data ) ); ?>">
+				<?php esc_html_e( 'Register Device', 'two-factor' ); ?>
+			</button>
+		</div>
+
+		<div class="webauthn-unsupported hidden">
+			<p class="description">
+				<span class="dashicons dashicons-warning"></span>
+				<?php esc_html_e( 'Your Browser does not support WebAuthn.', 'two-factor' ); ?>
+			</p>
+		</div>
+
+		<ul class="keys" id="webauthn-keys">
+			<?php
+			foreach ( $keys as $key ) {
+				echo wp_kses(
+					$this->get_key_item( $key, $user->ID ),
+					array(
+						'div'    => array(
+							'id'       => array(),
+							'class'    => array(),
+							'tabindex' => array(),
+						),
+						'ul'     => array(
+							'id'    => array(),
+							'class' => array(),
+						),
+						'li'     => array(
+							'id'    => array(),
+							'class' => array(),
+						),
+						'strong' => array(
+							'id'    => array(),
+							'class' => array(),
+						),
+						'small'  => array(
+							'id'    => array(),
+							'class' => array(),
+						),
+						'br'     => array(
+							'id'    => array(),
+							'class' => array(),
+						),
+						'em'     => array(
+							'id'    => array(),
+							'class' => array(),
+						),
+						'span'   => array(
+							'id'          => array(),
+							'class'       => array(),
+							'data-action' => array(),
+							'data-tested' => array(),
+							'tabindex'    => array(),
+						),
+						'a'      => array(
+							'id'          => array(),
+							'class'       => array(),
+							'data-action' => array(),
+							'tabindex'    => array(),
+							'href'        => array(),
+						),
+					)
+				);
+			}
+			?>
+		</ul>
+		<?php
+	}
+
+	/**
+	 * Registration Ajax Callback.
+	 */
+	public function ajax_register() {
+
+		check_ajax_referer( 'webauthn-register' );
+
+		if ( ! isset( $_REQUEST['payload'] ) ) {
+			// Error couldn't decode.
+			wp_send_json_error( new WP_Error( 'webauthn', __( 'Invalid request', 'two-factor' ) ) );
+		}
+
+		$credential = json_decode( wp_unslash( $_REQUEST['payload'] ) );
+
+		if ( JSON_ERROR_NONE !== json_last_error() ) {
+			// Error couldn't decode.
+			wp_send_json_error( new WP_Error( 'webauthn', esc_html( json_last_error_msg() ) ) );
+		}
+
+		if ( ! is_object( $credential ) ) {
+			// Contained some junk.
+			wp_send_json_error( new WP_Error( 'webauthn', __( 'Invalid credential', 'two-factor' ) ) );
+		}
+
+		// User id.
+		if ( isset( $_REQUEST['user_id'] ) ) {
+			$user_id = intval( wp_unslash( $_REQUEST['user_id'] ) );
+		} else {
+			wp_send_json_error( new WP_Error( 'webauthn', __( 'Invalid request data', 'two-factor' ) ) );
+		}
+		// Check permissions.
+		if ( ! current_user_can( 'edit_users' ) && get_current_user_id() !== $user_id ) {
+			wp_send_json_error( new WP_Error( 'webauthn', __( 'Not allowed to add key', 'two-factor' ) ) );
+		}
+
+		try {
+			$key = $this->webauthn->register( $credential, '' );
+
+			if ( false === $key ) {
+				wp_send_json_error( new WP_Error( 'webauthn', $this->webauthn->getLastError() ) );
+			}
+			/* translators: %s webauthn app id (domain) */
+			$key->label     = sprintf( esc_html__( 'New Device - %s', 'two-factor' ), $this->get_app_id() );
+			$key->md5id     = md5( implode( '', array_map( 'chr', $key->id ) ) );
+			$key->created   = time();
+			$key->last_used = false;
+			$key->tested    = false;
+
+			if ( false !== $this->key_store->key_exists( $key->md5id ) ) {
+				wp_send_json_error( new WP_Error( 'webauthn', esc_html__( 'Device already Exists', 'two-factor' ) ) );
+				exit();
+			}
+
+			$this->key_store->create_key( $user_id, $key );
+
+		} catch ( Exception $err ) {
+			wp_send_json(
+				array(
+					'success' => false,
+					'error'   => $err->getMessage(),
+				)
+			);
+			return;
+		}
+
+		wp_send_json(
+			array(
+				'success' => true,
+				'html'    => $this->get_key_item( $key, $user_id ),
+			)
+		);
+	}
+
+	/**
+	 * Edit Key Ajax Callback.
+	 */
+	public function ajax_edit_key() {
+
+		check_ajax_referer( 'webauthn-edit-key' );
+
+		if ( ! isset( $_REQUEST['payload'] ) ) {
+			// Error couldn't decode.
+			wp_send_json_error( new WP_Error( 'webauthn', __( 'Invalid request', 'two-factor' ) ) );
+		}
+
+		$current_user_id = get_current_user_id();
+
+		if ( isset( $_REQUEST['user_id'] ) ) {
+			$user_id = intval( wp_unslash( $_REQUEST['user_id'] ) );
+		} else {
+			wp_send_json_error( new WP_Error( 'webauthn', __( 'Invalid request data', 'two-factor' ) ) );
+		}
+		// Not permitted.
+		if ( ! current_user_can( 'edit_users' ) && $user_id !== $current_user_id ) {
+			wp_send_json_error( new WP_Error( 'webauthn', __( 'Operation not permitted', 'two-factor' ) ) );
+		}
+
+		$payload = wp_unslash( $_REQUEST['payload'] );
+
+		if ( ! isset( $payload['md5id'], $payload['label'] ) ) {
+			wp_send_json_error( new WP_Error( 'webauthn', esc_html__( 'Invalid request', 'two-factor' ) ) );
+		}
+		$new_label = sanitize_text_field( $payload['label'] );
+
+		if ( empty( $new_label ) ) {
+			wp_send_json_error( new WP_Error( 'webauthn', esc_html__( 'Invalid label', 'two-factor' ) ) );
+		}
+
+		$key = $this->key_store->find_key( $user_id, $payload['md5id'] );
+		if ( ! $key ) {
+			wp_send_json_error( new WP_Error( 'webauthn', esc_html__( 'No such key', 'two-factor' ) ) );
+		}
+
+		$key->label = $new_label;
+
+		if ( $this->key_store->save_key( $user_id, $key, $payload['md5id'] ) ) {
+			wp_send_json(
+				array(
+					'success' => true,
+				)
+			);
+		}
+
+		wp_send_json_error( new WP_Error( 'webauthn', esc_html__( 'Could not edit key', 'two-factor' ) ) );
+	}
+
+	/**
+	 * Delete Key Ajax Callback.
+	 */
+	public function ajax_delete_key() {
+
+		check_ajax_referer( 'webauthn-delete-key' );
+
+		if ( ! isset( $_REQUEST['payload'] ) ) {
+
+			// Error couldn't decode.
+			wp_send_json_error( new WP_Error( 'webauthn', __( 'Invalid request', 'two-factor' ) ) );
+		}
+
+		$key_id = wp_unslash( $_REQUEST['payload'] );
+
+		$current_user_id = get_current_user_id();
+
+		if ( isset( $_REQUEST['user_id'] ) ) {
+			$user_id = intval( wp_unslash( $_REQUEST['user_id'] ) );
+		} else {
+			$user_id = $current_user_id;
+		}
+
+		// Not permitted.
+		if ( ! current_user_can( 'edit_users' ) && $user_id !== $current_user_id ) {
+			wp_send_json_error( new WP_Error( 'webauthn', __( 'Operation not permitted', 'two-factor' ) ) );
+		}
+
+		if ( $this->key_store->delete_key( $user_id, $key_id ) ) {
+			wp_send_json(
+				array(
+					'success' => true,
+				)
+			);
+		}
+
+		wp_send_json_error( new WP_Error( 'webauthn', esc_html__( 'Could not delete key', 'two-factor' ) ) );
+	}
+
+	/**
+	 * Test Key Ajax Callback.
+	 */
+	public function ajax_test_key() {
+
+		check_ajax_referer( 'webauthn-test-key' );
+
+		if ( ! isset( $_REQUEST['payload'] ) ) {
+			// error couldn't decode.
+			wp_send_json_error( new WP_Error( 'webauthn', __( 'Invalid request', 'two-factor' ) ) );
+		}
+
+		$credential = wp_unslash( $_REQUEST['payload'] );
+
+		$current_user_id = get_current_user_id();
+
+		if ( isset( $_REQUEST['user_id'] ) ) {
+			$user_id = intval( wp_unslash( $_REQUEST['user_id'] ) );
+		} else {
+			wp_send_json_error( new WP_Error( 'webauthn', __( 'Invalid request data', 'two-factor' ) ) );
+		}
+
+		// Not permitted.
+		if ( ! current_user_can( 'edit_users' ) && $user_id !== $current_user_id ) {
+			wp_send_json_error( new WP_Error( 'webauthn', __( 'Operation not permitted', 'two-factor' ) ) );
+		}
+
+		$keys = $this->key_store->get_keys( $user_id );
+
+		$key = $this->webauthn->authenticate( json_decode( $credential ), $keys );
+
+		if ( false !== $key ) {
+			// store key tested state.
+			$key->tested = true;
+			$this->key_store->save_key( $user_id, $key, $key->md5id );
+		}
+
+		wp_send_json(
+			array(
+				'success' => false !== $key,
+				'message' => $this->webauthn->getLastError(),
+			)
+		);
+	}
+
+	/**
+	 * Key Row HTML.
+	 *
+	 * @param object $pub_key Public key as generated by $this->webauthn->register().
+	 * @param int    $user_id User ID.
+	 * @return string HTML.
+	 */
+	private function get_key_item( $pub_key, $user_id ) {
+
+		$out = '<li class="webauthn-key">';
+
+		// Info.
+		$out .= sprintf(
+			'<span class="webauthn-label webauthn-action" data-action="%1$s" tabindex="1">%2$s</span>',
+			esc_attr(
+				wp_json_encode(
+					array(
+						'action'   => 'webauthn-edit-key',
+						'payload'  => $pub_key->md5id,
+						'userId'   => $user_id,
+						'_wpnonce' => wp_create_nonce( 'webauthn-edit-key' ),
+					)
+				)
+			),
+			esc_html( $pub_key->label )
+		);
+
+		$date_format = _x( 'm/d/Y', 'Short date format', 'two-factor' );
+
+		$out .= sprintf(
+			'<span class="webauthn-created"><small>%s</small><br />%s</span>',
+			__( 'Created:', 'two-factor' ),
+			date_i18n( $date_format, $pub_key->created )
+		);
+		$out .= sprintf(
+			'<span class="webauthn-used"><small>%s</small><br />%s</span>',
+			__( 'Last used:', 'two-factor' ),
+			$pub_key->last_used ? date_i18n( $date_format, $pub_key->last_used ) : esc_html__( '- Never -', 'two-factor' )
+		);
+
+		// Actions.
+		$out .= sprintf(
+			'<a href="#" class="webauthn-action webauthn-action-link -test webauthn-supported" title="%1$s" data-action="%2$s" >
+				%1$s
+				<span class="dashicons dashicons-yes-alt" data-tested="%3$s"></span>
+			</a>',
+			esc_html__( 'Test', 'two-factor' ),
+			esc_attr(
+				wp_json_encode(
+					array(
+						'action'   => 'webauthn-test-key',
+						'payload'  => $this->webauthn->prepareAuthenticate( array( $pub_key ) ),
+						'userId'   => $user_id,
+						'_wpnonce' => wp_create_nonce( 'webauthn-test-key' ),
+					)
+				)
+			),
+			$pub_key->tested ? 'tested' : 'untested'
+		);
+		$out .= sprintf(
+			'<a href="#" class="webauthn-action webauthn-action-link -delete webauthn-supported" title="%1$s" data-action="%2$s">
+				<span class="dashicons dashicons-trash"></span>
+				<span class="screen-reader-text">%1$s</span>
+			</a>',
+			esc_html__( 'Delete', 'two-factor' ),
+			esc_attr(
+				wp_json_encode(
+					array(
+						'action'   => 'webauthn-delete-key',
+						'payload'  => $pub_key->md5id,
+						'userId'   => $user_id,
+						'_wpnonce' => wp_create_nonce( 'webauthn-delete-key' ),
+					)
+				)
+			)
+		);
+		$out .= '</li>';
+
+		return $out;
+	}
+
+}

--- a/providers/webauthn/includes/class-cbor-decoder.php
+++ b/providers/webauthn/includes/class-cbor-decoder.php
@@ -1,0 +1,296 @@
+<?php
+
+/**
+ * CBOR decoder
+ * adapted from 2tvenom/cborencode
+ *
+ * Class CBORDecoder
+ */
+class CBORDecoder {
+    const
+        MAJOR_OFFSET = 5,
+        HEADER_WIPE = 0b00011111,
+        ADDITIONAL_WIPE = 0b11100000,
+        MAJOR_TYPE_UNSIGNED_INT = 0b000000, //0
+        MAJOR_TYPE_INT = 0b100000, //1
+        MAJOR_TYPE_BYTE_STRING = 0b1000000, //2
+        MAJOR_TYPE_UTF8_STRING = 0b1100000, //3
+        MAJOR_TYPE_ARRAY = 0b10000000, //4
+        MAJOR_TYPE_MAP = 0b10100000, //5
+        MAJOR_TYPE_TAGS = 0b11000000, //6
+        MAJOR_TYPE_SIMPLE_AND_FLOAT = 0b11100000, //7
+        MAJOR_TYPE_INFINITE_CLOSE = 0xFF,
+        ADDITIONAL_MAX = 23,
+        ADDITIONAL_TYPE_INT_FALSE = 20,
+        ADDITIONAL_TYPE_INT_TRUE = 21,
+        ADDITIONAL_TYPE_INT_NULL = 22,
+        ADDITIONAL_TYPE_INT_UNDEFINED = 23,
+        ADDITIONAL_TYPE_INT_UINT8 = 24,
+        ADDITIONAL_TYPE_INT_UINT16 = 25,
+        ADDITIONAL_TYPE_INT_UINT32 = 26,
+        ADDITIONAL_TYPE_INT_UINT64 = 27,
+        ADDITIONAL_TYPE_FLOAT16 = 25, //not support
+        ADDITIONAL_TYPE_FLOAT32 = 26, //encode not support
+        ADDITIONAL_TYPE_FLOAT64 = 27,
+        ADDITIONAL_TYPE_INFINITE = 31;
+
+    private static $length_pack_type = array(
+        self::ADDITIONAL_TYPE_INT_UINT8 => "C",
+        self::ADDITIONAL_TYPE_INT_UINT16 => "n",
+        self::ADDITIONAL_TYPE_INT_UINT32 => "N",
+        self::ADDITIONAL_TYPE_INT_UINT64 => null,
+    );
+
+    private static $float_pack_type = array(
+        self::ADDITIONAL_TYPE_FLOAT32 => "f",
+        self::ADDITIONAL_TYPE_FLOAT64 => "d",
+    );
+
+    private static $byte_length = array(
+        self::ADDITIONAL_TYPE_INT_UINT8 => 1,
+        self::ADDITIONAL_TYPE_INT_UINT16 => 2,
+        self::ADDITIONAL_TYPE_INT_UINT32 => 4,
+        self::ADDITIONAL_TYPE_INT_UINT64 => 8,
+    );
+
+    /**
+     * Decode CBOR byte string
+     * @param mixed $var
+     * @throws \Exception
+     * @return mixed
+     */
+    public static function decode(&$var){
+        $out = null;
+
+        //get initial byte
+        $unpacked = unpack("C*", substr($var, 0, 1));
+        $header_byte = array_shift($unpacked);
+
+        if ($header_byte == self::MAJOR_TYPE_INFINITE_CLOSE) {
+            $major_type = $header_byte;
+            $additional_info = 0;
+        } else {
+            //unpack major type
+            $major_type = $header_byte & self::ADDITIONAL_WIPE;
+            //get additional_info
+            $additional_info = self::unpack_additional_info($header_byte);
+        }
+
+        $byte_data_offset = 1;
+        if(array_key_exists($additional_info, self::$byte_length)){
+            $byte_data_offset += self::$byte_length[$additional_info];
+        }
+
+        switch($major_type) {
+            case self::MAJOR_TYPE_UNSIGNED_INT:
+            case self::MAJOR_TYPE_INT:
+                //decode int
+                $out = self::decode_int($additional_info, $var);
+
+                if($major_type == self::MAJOR_TYPE_INT){
+                    $out = -($out+1);
+                }
+
+                break;
+            case self::MAJOR_TYPE_BYTE_STRING:
+            case self::MAJOR_TYPE_UTF8_STRING:
+                $string_length = self::decode_int($additional_info, $var);
+
+                $out = substr($var, $byte_data_offset, $string_length);
+
+                if($major_type == self::MAJOR_TYPE_BYTE_STRING) {
+                    $out = new CBORByteString($out);
+                }
+
+                $byte_data_offset += $string_length;
+                break;
+            case self::MAJOR_TYPE_ARRAY:
+            case self::MAJOR_TYPE_MAP:
+                $out = array();
+
+                $elem_count = $additional_info != self::ADDITIONAL_TYPE_INFINITE ?
+                    self::decode_int($additional_info, $var) : PHP_INT_MAX;
+                $var = substr($var, $byte_data_offset);
+
+                while($elem_count > count($out))
+                {
+                    $primitive = self::decode($var);
+                    if (is_null($primitive)) {
+                        break;
+                    }
+                    if($major_type == self::MAJOR_TYPE_MAP) {
+                        $out[$primitive] = self::decode($var);
+                    } else {
+                        $out[] = $primitive;
+                    }
+                }
+
+                break;
+            case self::MAJOR_TYPE_TAGS:
+                throw new \Exception("Not implemented. Sorry");
+                break;
+            case self::MAJOR_TYPE_SIMPLE_AND_FLOAT:
+                $out = self::decode_simple_float($additional_info, $var);
+                break;
+            case self::MAJOR_TYPE_INFINITE_CLOSE:
+                $out = null;
+        }
+
+        if(!in_array($major_type, array(self::MAJOR_TYPE_ARRAY, self::MAJOR_TYPE_MAP))){
+            $var = substr($var, $byte_data_offset);
+        }
+
+        return $out;
+    }
+
+    /**
+     * Unpack data length/int
+     * @param $length_capacity
+     * @param $byte_string
+     * @throws Exception
+     * @internal param $length
+     * @return int|null
+     */
+    private static function decode_int($length_capacity, &$byte_string){
+
+        if($length_capacity <= self::ADDITIONAL_MAX) return $length_capacity;
+        $decoding_byte_string = substr($byte_string, 1, self::$byte_length[$length_capacity]);
+        switch(true)
+        {
+            case $length_capacity == self::ADDITIONAL_TYPE_INT_UINT64:
+                return self::bigint_unpack($decoding_byte_string);
+                break;
+            case array_key_exists($length_capacity, self::$length_pack_type):
+                $typed_int = unpack(self::$length_pack_type[$length_capacity], $decoding_byte_string);
+                return array_shift($typed_int);
+                break;
+            default:
+                throw new Exception("CBOR Incorrect additional info");
+                break;
+        }
+
+        return null;
+    }
+
+    /**
+     * Unpack double/bool/null
+     * @param $length_capacity
+     * @param $byte_string
+     * @return null|string
+     */
+    private static function decode_simple_float($length_capacity, &$byte_string){
+        $simple_association = array(
+            self::ADDITIONAL_TYPE_INT_FALSE => false,
+            self::ADDITIONAL_TYPE_INT_TRUE => true,
+            self::ADDITIONAL_TYPE_INT_NULL => null,
+            self::ADDITIONAL_TYPE_INT_UNDEFINED => NAN,
+        );
+
+        if(array_key_exists($length_capacity, $simple_association))
+        {
+            return $simple_association[$length_capacity];
+        }
+        $typed_float = unpack(self::$float_pack_type[$length_capacity], strrev(substr($byte_string, 1, self::$byte_length[$length_capacity])));
+        return array_shift($typed_float);
+    }
+
+    /**
+     * Unpack additional info
+     * @param $byte
+     * @return int
+     */
+    private static function unpack_additional_info($byte)
+    {
+        return $byte & self::HEADER_WIPE;
+    }
+
+    /**
+     * Pack initial byte NOT IN USE
+     * @param $major_type
+     * @param $additional_info
+     * @return string
+     */
+    private static function pack_init_byte($major_type, $additional_info)
+    {
+        return pack("c", $major_type | $additional_info);
+    }
+
+    /**
+     * Get length of int NOT IN USE
+     * @param $int
+     * @return int|null
+     */
+    private static function get_length($int)
+    {
+        switch(true)
+        {
+            case $int < 256:
+                return self::ADDITIONAL_TYPE_INT_UINT8;
+                break;
+            case $int < 65536:
+                return self::ADDITIONAL_TYPE_INT_UINT16;
+                break;
+            case $int < 4294967296:
+                return self::ADDITIONAL_TYPE_INT_UINT32;
+                break;
+            //are you seriously?
+            case $int < 9223372036854775807:
+                return null;
+                break;
+        }
+        return null;
+    }
+
+    /**
+     * Array is associative or not
+     *
+     * @param $arr
+     * @return bool
+     */
+    private static function is_assoc(&$arr)
+    {
+        return array_keys($arr) !== range(0, count($arr) -1);
+    }
+
+    /**
+     * Split big int in two 32 bit parts and pack
+     * @param $big_int
+     * @return string
+     */
+    private static function bigint_unpack($big_int)
+    {
+        list($higher, $lower) = array_values(unpack("N2", $big_int));
+        return $higher << 32 | $lower;
+    }
+
+    private static function bigint_pack($big_int)
+    {
+        return pack("NN", ($big_int & 0xffffffff00000000) >> 32, ($big_int & 0x00000000ffffffff));
+    }
+}
+
+
+class CBORByteString {
+    private $byte_string = null;
+
+    public function __construct($byte_string)
+    {
+        $this->byte_string = $byte_string;
+    }
+
+    /**
+     * @return null
+     */
+    public function get_byte_string()
+    {
+        return $this->byte_string;
+    }
+
+    /**
+     * @param null $byte_string
+     */
+    public function set_byte_string($byte_string)
+    {
+        $this->byte_string = $byte_string;
+    }
+}

--- a/providers/webauthn/includes/class-webauthn-handler.php
+++ b/providers/webauthn/includes/class-webauthn-handler.php
@@ -1,0 +1,750 @@
+<?php
+
+if ( ! defined('ABSPATH') ) {
+	die('Bye!');
+}
+
+/**
+ *	Adapted from https://github.com/davidearl/webauthn
+ */
+
+class WebAuthnHandler {
+
+	private $last_call = null;
+	private $last_error = array(
+		'authenticate' => false,
+		'prepareAuthenticate' => false,
+		'register' => false,
+		'prepareRegister' => false,
+	);
+
+	const ES256 = -7;
+	const RS256 = -257; // Windows Hello support
+
+	/**
+	* construct object on which to operate
+	*
+	* @param string $appid a string identifying your app, typically the domain of your website which people
+	*                      are using the key to log in to. If you have the URL (ie including the
+	*                      https:// on the front) to hand, give that;
+	*                      if it's not https, well what are you doing using this code?
+	*/
+	public function __construct($appid)
+	{
+		if (! is_string($appid)) {
+			throw new Exception('appid must be a string');
+		}
+		$this->appid = $appid;
+		if (strpos($this->appid, 'https://') === 0) {
+			$this->appid = substr($this->appid, 8); /* drop the https:// */
+		}
+	}
+
+	/**
+	 *	Return last error depending on request
+	 */
+	public function getLastError( string $realm = NULL ) {
+		if ( is_null( $realm ) ) {
+			$realm = $this->last_call;
+		}
+		if ( is_null( $realm ) ) {
+			return false;
+		}
+		if ( ! isset( $this->last_error[ $realm ] ) ) {
+			return false;
+		}
+		return $this->last_error[ $realm ];
+	}
+
+	/**
+	* generate a challenge ready for registering a hardware key, fingerprint or whatever:
+	* @param $username string by which the user is known potentially displayed on the hardware key
+	* @param $userid string by which the user can be uniquely identified. Don't use email address as this can change,
+	*                user perhaps the database record id
+	* @param $crossPlatform bool default=FALSE, whether to link the identity to the key (TRUE, so it
+	*               can be used cross-platofrm, on different computers) or the platform (FALSE, only on
+	*               this computer, but with any available authentication device, e.g. known to Windows Hello)
+	* @return string pass this JSON string back to the browser
+	*/
+	public function prepareRegister($username, $userid, $crossPlatform = FALSE)
+	{
+		$result = (object) array();
+		$rbchallenge = self::randomBytes(16);
+		$result->challenge = self::stringToArray($rbchallenge);
+		$result->user = (object) array();
+		$result->user->name = $result->user->displayName = $username;
+		$result->user->id = self::stringToArray($userid);
+
+		$result->rp = (object) array();
+		$result->rp->name = $result->rp->id = $this->appid;
+
+		$result->pubKeyCredParams = array(
+			array(
+				'alg' => self::ES256,
+				'type' => 'public-key'
+			),
+			array(
+				'alg' => self::RS256,
+				'type' => 'public-key'
+			)
+		);
+
+		$result->authenticatorSelection = (object) array();
+		if ( $crossPlatform ) {
+			$result->authenticatorSelection->authenticatorAttachment = 'cross-platform';
+		}
+
+		$result->authenticatorSelection->requireResidentKey = false;
+		$result->authenticatorSelection->userVerification = 'discouraged';
+
+		$result->attestation = null;
+		$result->timeout = 60000;
+		$result->excludeCredentials = array(); // No excludeList
+		$result->extensions = (object) array();
+		$result->extensions->exts = true;
+
+		return array(
+			'publicKey' => $result,
+			'b64challenge' => rtrim( strtr( base64_encode( $rbchallenge ), '+/', '-_'), '=')
+		);
+	}
+
+	/**
+	* registers a new key for a user
+	* requires info from the hardware via javascript given below
+	* @param object $info supplied to the PHP script via a POST, constructed by the Javascript given below, ultimately
+	*        provided by the key
+	* @param string $userwebauthn the exisitng webauthn field for the user from your
+	*        database (it's actaully a JSON string, but that's entirely internal to
+	*        this code)
+	* @return boolean|object user key
+	*/
+	public function register( object $info ) {
+
+		$this->last_call = __FUNCTION__;
+
+		$this->last_error[ $this->last_call ] = false;
+
+		// check info
+		if ( false === $this->validateRegisterInfo( $info ) ) {
+			// error generated in validateRegisterInfo()
+			return false;
+		}
+
+    	/* check response from key and store as new identity. This is a hex string representing the raw CBOR
+    	attestation object received from the key */
+
+		$attData = $this->parseAttestationObject( $info->response->attestationObject );
+
+		// check info
+		if ( false === $attData ) {
+			// error generated in parseAttestationObject()
+			return false;
+		}
+
+    	if ( $attData->credId !== self::arrayToString( $info->rawId ) ) {
+			$this->last_error[ $this->last_call ] = 'ao-id-mismatch';
+			return false;
+    	}
+
+    	return (object) array(
+			'key' => $attData->keyBytes,
+			'id' => $info->rawId,
+		);
+
+	}
+
+	/**
+	* generates a new key string for the physical key, fingerprint
+	* reader or whatever to respond to on login
+	* @param array $userKeys the existing webauthn field for the user from your database
+	* @return boolean|object Object to pass to javascript webauthnAuthenticate or false on faliue
+	*/
+	public function prepareAuthenticate( array $userKeys = array() )
+	{
+		$allowKeyDefaults = array(
+			'transports' =>  array( 'usb','nfc','ble','internal' ),
+			'type' => 'public-key',
+		);
+    	$allows = array();
+		foreach ( $userKeys as $key) {
+			if ( $this->isValidKey( $key ) ) {
+				$allows[] = (object) ( array(
+					'id' => $key->id,
+				) + $allowKeyDefaults );
+			}
+		}
+
+		if ( ! count( $allows ) ) {
+			/* including empty user, so they can't tell whether the user exists or not (need same result each
+			time for each user) */
+			$rb = md5( (string) time() );
+			$allows[] = (object) (array(
+				'id' => self::stringToArray( $rb ),
+			) + $allowKeyDefaults);
+		}
+
+		/* generate key request */
+		$publickey = (object) array();
+		$publickey->challenge = self::stringToArray( self::randomBytes(16) );
+		$publickey->timeout = 60000;
+		$publickey->allowCredentials = $allows;
+		$publickey->userVerification = 'discouraged';
+		$publickey->extensions = (object) array();
+		// $publickey->extensions->txAuthSimple = 'Execute order 66';
+		$publickey->rpId = str_replace('https://', '', $this->appid );
+
+		return $publickey;
+	}
+
+	/**
+	* validates a response for login or 2fa
+	* requires info from the hardware via javascript given below
+	* @param object $info supplied to the PHP script via POST, constructed by the Javascript given below, ultimately
+	*        provided by the key
+	* @param array $userKeys the exisiting webauthn field for the user from your
+	*        database
+	* @return object|null the matching key object from $userKeys for a valid authentication, null otherwise
+	*/
+	public function authenticate( object $info, array $userKeys )
+	{
+
+		$this->last_call = __FUNCTION__;
+
+		$this->last_error[ $this->last_call ] = false;
+
+		// check info
+		if ( ! $this->validateAuthenticateInfo( $info ) ) {
+			return false;
+		}
+
+		$key = $this->findKeyById( $info->rawId, $userKeys );
+
+		if ( false === $key ) {
+			$this->last_error[ $this->last_call ] = 'no-matching-key';
+			return false;
+		}
+
+
+		$bs = self::arrayToString( $info->response->authenticatorData );
+		$ao = (object)array();
+
+		$ao->rpIdHash = substr( $bs, 0, 32 );
+		$ao->flags = ord( substr( $bs, 32, 1 ) );
+		$ao->counter = substr( $bs, 33, 4 );
+
+		$hashId = hash( 'sha256', $this->appid, true );
+
+		if ( $hashId !== $ao->rpIdHash ) {
+			$this->last_error[ $this->last_call ] = 'key-response-decode-hash-mismatch';
+			return false;
+		}
+
+		/* experience shows that at least one device (OnePlus 6T/Pie (Android phone)) doesn't set this,
+		so this test would fail. This is not correct according to the spec, so  pragmatically it may
+		have to be removed */
+		if ( ( $ao->flags & 0x1 ) != 0x1 ) {
+			$this->last_error[ $this->last_call ] = 'key-response-decode-flags-mismatch';
+			return false;
+		} /* only TUP must be set */
+
+		/* assemble signed data */
+		$clientdata = self::arrayToString( $info->response->clientDataJSONarray );
+		$signeddata = $hashId . chr( $ao->flags ) . $ao->counter . hash( 'sha256', $clientdata, true );
+
+		if (count( $info->response->signature ) < 70) {
+			$this->last_error[ $this->last_call ] = 'key-response-decode-signature-invalid';
+			return false;
+		}
+
+		$signature = self::arrayToString($info->response->signature);
+
+		$verify_result = openssl_verify( $signeddata, $signature, $key->key, OPENSSL_ALGO_SHA256 );
+
+		if ( 1 === $verify_result ) {
+			$this->last_error[ $this->last_call ] = false;
+			return $key;
+		} else if ( 0 === $verify_result ) {
+			$this->last_error[ $this->last_call ] = 'key-not-verfied';
+			return false;
+		}
+
+		$this->last_error[ $this->last_call ] = openssl_error_string();
+
+		return false;
+
+    }
+
+	/**
+	 *	Parse and validate Attestation object
+	 *
+	 *	@param array $ao_arr Attestation Object byte array
+	 *	@return boolean|object attestedCredentialData false on failure
+	 *
+	 *	@see https://developer.mozilla.org/en-US/docs/Web/API/AuthenticatorAssertionResponse/authenticatorData
+	 */
+	private function parseAttestationObject( array $ao_arr ) {
+
+		//
+		$ao_cbor = self::arrayToString( $ao_arr );
+		/**
+		 *	Fires before an attestiation object is parsed
+		 *
+		 *	@param String $ao_cbor Byte string
+		 */
+		do_action( 'two_factor_webauthn_parse_attestation_object', $ao_cbor );
+		$ao = (object)( CBORDecoder::decode( $ao_cbor ) );
+
+		// begin validation
+		if ( ! is_object( $ao ) ) {
+			$this->last_error[ $this->last_call ] = 'ao-not-object';
+			return false;
+		}
+
+        if ( empty( $ao ) ) {
+			$this->last_error[ $this->last_call ] = 'ao-empty';
+			return false;
+        }
+
+        if ( ! isset( $ao->fmt, $ao->authData ) ) {
+			$this->last_error[ $this->last_call ] = 'ao-missing-property';
+			return false;
+        }
+
+		if ( ! is_string( $ao->fmt ) ) {
+			$this->last_error[ $this->last_call ] = 'ao-fmt-invalid';
+			return false;
+        }
+		if ( ! ( $ao->authData instanceof CBORByteString ) ) {
+			$this->last_error[ $this->last_call ] = 'ao-authdata-invalid';
+			return false;
+		}
+
+		if ( ! in_array( $ao->fmt, array( 'none', 'packed' ) ) ) {
+			$this->last_error[ $this->last_call ] = 'ao-fmt-unsupported';
+			return false;
+		}
+
+		$bs = $ao->authData->get_byte_string();
+		/**
+		 *	Fires before an attestiation object is parsed
+		 *
+		 *	@param String $ao_cbor Byte string
+		 */
+		do_action( 'two_factor_webauthn_parse_auth_data', $bs );
+
+		if ( empty( $bs ) ) {
+			$this->last_error[ $this->last_call ] = 'ao-authdata-empty';
+			return false;
+		}
+
+		//
+		$authData = (object) array(
+			'rpIdHash' => substr($bs, 0, 32),
+			'flags' => ord(substr($bs, 32, 1)),
+			'signCount' => substr($bs, 33, 4),
+		);
+
+		if ( ! ( $authData->flags & 0x41 ) ) {
+			$this->last_error[ $this->last_call ] = 'ao-flags-unsupported';
+			return false;
+		}
+
+		$hashId = hash('sha256', $this->appid, true);
+
+		if ( $hashId != $authData->rpIdHash ) {
+			$this->last_error[ $this->last_call ] = 'ao-appid-mismatch';
+			return false;
+		}
+
+		$attData = (object) array(
+			'aaguid' => substr($bs, 37, 16),
+			'credIdLen' => ( ord( $bs[53] ) << 8 ) + ord( $bs[54] ),
+		);
+
+		$attData->credId = substr( $bs, 55, $attData->credIdLen );
+		$attData->keyBytes = self::COSEECDHAtoPKCS(
+			substr( $bs, 55 + $attData->credIdLen )
+		);
+
+		return $attData;
+
+	}
+
+	/**
+	 *	Validates First argument of authenticate.
+	 *	@param object $info
+	 *	@return boolean
+	 */
+	private function validateRegisterInfo( object $info ) {
+		/*
+		$info
+			->rawId					Uint8Array
+			->response
+				->attestationObject	Uint8Array : CBOR
+
+		*/
+		if ( ! isset( $info->rawId, $info->response ) ) {
+			$this->last_error[ $this->last_call ] = 'info-missing-property';
+			return false;
+		}
+		if ( ! is_array( $info->rawId ) || ! is_object( $info->response ) ) {
+			$this->last_error[ $this->last_call ] = 'info-malformed-property';
+			return false;
+		}
+		if ( ! isset( $info->response->attestationObject ) ) {
+			$this->last_error[ $this->last_call ] = 'info-response-missing-property';
+			return false;
+		}
+		if ( ! is_array( $info->response->attestationObject ) ) {
+			$this->last_error[ $this->last_call ] = 'info-response-malformed-property';
+			return false;
+		}
+
+		return true;
+
+	}
+
+
+
+
+	/**
+	 *	Validates First argument of authenticate.
+	 *	@param object $info
+	 *	@return boolean
+	 */
+	private function validateAuthenticateInfo( object $info ) {
+		/*
+		$info
+			->rawId array				Uint8Array
+			->originalChallenge			Uint8Array
+			->response
+				->clientData
+					->challenge			base64string
+					->origin			string URL
+					->type 				string 'webauthn.get'
+				->clientDataJSONarray	Uint8Array
+				->authenticatorData		Uint8Array
+				->signature 			Uint8Array
+		*/
+		// check existence 1st level
+		if ( ! isset( $info->rawId, $info->originalChallenge, $info->response ) ) {
+			$this->last_error[ $this->last_call ] = 'info-missing-property';
+			return false;
+		}
+		// check types 1st level
+		if ( ! is_array( $info->rawId ) || ! is_array( $info->originalChallenge ) || ! is_object( $info->response ) ) {
+			$this->last_error[ $this->last_call ] = 'info-malformed-value';
+			return false;
+		}
+
+		// check existence 2nd level
+		if ( ! isset( $info->response->clientData, $info->response->clientDataJSONarray, $info->response->authenticatorData, $info->response->signature ) ) {
+			$this->last_error[ $this->last_call ] = 'info-response-missing-property';
+			return false;
+		}
+		// check types 2nd level
+		if ( ! is_object( $info->response->clientData ) || ! is_array( $info->response->clientDataJSONarray ) || ! is_array( $info->response->authenticatorData ) || ! is_array( $info->response->signature ) ) {
+			$this->last_error[ $this->last_call ] = 'info-response-malformed-value';
+			return false;
+		}
+
+		// check existence 3rd level
+		if ( ! isset(
+				$info->response->clientData->challenge,
+				$info->response->clientData->origin,
+				$info->response->clientData->type
+			)
+	 	) {
+			$this->last_error[ $this->last_call ] = 'info-clientdata-missing-property';
+			return false;
+		}
+
+		// check types 3rd level
+		if (
+			! is_string( $info->response->clientData->challenge ) ||
+			! is_string( $info->response->clientData->origin ) ||
+			! is_string( $info->response->clientData->type )
+	 	) {
+			$this->last_error[ $this->last_call ] = 'info-clientdata-malformed-value';
+			return false;
+		}
+
+		if ( $info->response->clientData->type != 'webauthn.get') {
+			$this->last_error[ $this->last_call ] = "info-wrong-type";
+			return false;
+        }
+
+
+		/* cross-check challenge */
+        if ( $info->response->clientData->challenge
+					!==
+			rtrim( strtr( base64_encode( self::arrayToString( $info->originalChallenge ) ), '+/', '-_'), '=')
+		) {
+			$this->last_error[ $this->last_call ] = 'info-challenge-mismatch';
+			return false;
+        }
+
+		/* cross check origin */
+        $origin = parse_url( $info->response->clientData->origin );
+
+        if ( strpos( $origin['host'], $this->appid ) !== ( strlen( $origin['host'] ) - strlen( $this->appid ) ) ) {
+
+			$this->last_error[ $this->last_call ] = 'info-origin-mismatch';
+			return false;
+        }
+
+
+		return true;
+
+
+	}
+
+
+	/**
+	 *	Find key by ID
+	 *	@param array $keyId
+	 *	@param array $keys Contains key objects (object) [ 'id' => [ int, int, ...], 'key' => '-----BEGIN PUBLIC KEY--...' ]
+	 */
+	private function findKeyById( array $keyId, array $keys ) {
+
+		$keyIdString = implode( ',', $keyId );
+
+		foreach ( $keys as $key ) {
+			// check for key format
+			if ( ! $this->isValidKey( $key ) ) {
+				continue;
+			}
+			if ( implode(',', $key->id ) === $keyIdString ) {
+				return $key;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 *	@param object $key
+	 *	@return boolean
+	 */
+	private function isValidKey( $key ) {
+		 return is_object( $key ) && isset( $key->id ) && is_array( $key->id ) && isset( $key->key ) && is_string( $key->key );
+	}
+
+
+	/**
+	 * convert an array of uint8's to a binary string
+	 * @param array $a to be converted (array of unsigned 8 bit integers)
+	 * @return string converted to bytes
+	 */
+	private static function arrayToString($a)
+	{
+		$s = '';
+		foreach ($a as $c) {
+			$s .= chr($c);
+		}
+		return $s;
+	}
+
+	/**
+	 * convert a binary string to an array of uint8's
+	 * @param string $s to be converted
+	 * @return array converted to array of unsigned integers
+	 */
+	private static function stringToArray($s)
+	{
+		/* convert binary string to array of uint8 */
+		$a = array();
+		for ($idx = 0; $idx < strlen($s); $idx++) {
+			$a[] = ord($s[$idx]);
+		}
+		return $a;
+	}
+
+	/**
+	 * convert a public key from the hardware to PEM format
+	 * @param string $key to be converted to PEM format
+	 * @return string converted to PEM format
+	 */
+	private function pubkeyToPem($key)
+	{
+		/* see https://github.com/Yubico/php-u2flib-server/blob/master/src/u2flib_server/U2F.php */
+		if (strlen($key) !== 65 || $key[0] !== "\x04") {
+			return null;
+		}
+		/*
+		* Convert the public key to binary DER format first
+		* Using the ECC SubjectPublicKeyInfo OIDs from RFC 5480
+		*
+		*  SEQUENCE(2 elem)                        30 59
+		*   SEQUENCE(2 elem)                       30 13
+		*    OID1.2.840.10045.2.1 (id-ecPublicKey) 06 07 2a 86 48 ce 3d 02 01
+		*    OID1.2.840.10045.3.1.7 (secp256r1)    06 08 2a 86 48 ce 3d 03 01 07
+		*   BIT STRING(520 bit)                    03 42 ..key..
+		*/
+		$der  = "\x30\x59\x30\x13\x06\x07\x2a\x86\x48\xce\x3d\x02\x01";
+		$der .= "\x06\x08\x2a\x86\x48\xce\x3d\x03\x01\x07\x03\x42";
+		$der .= "\x00".$key;
+		$pem  = "-----BEGIN PUBLIC KEY-----\x0A";
+		$pem .= chunk_split(base64_encode($der), 64, "\x0A");
+		$pem .= "-----END PUBLIC KEY-----\x0A";
+		return $pem;
+	}
+
+	/**
+	* Convert COSE ECDHA to PKCS
+	* @param string binary string to be converted
+	* @return string converted public key
+	*/
+	private function COSEECDHAtoPKCS($binary)
+	{
+		$cosePubKey = CBORDecoder::decode($binary);
+
+		if (! isset($cosePubKey[3] /* cose_alg */)) {
+			throw new Exception('cannot decode key response (8)');
+		}
+
+		switch ($cosePubKey[3]) {
+			case self::ES256:
+			/* COSE Alg: ECDSA w/ SHA-256 */
+				if (! isset($cosePubKey[-1] /* cose_crv */)) {
+					throw new Exception('cannot decode key response (9)');
+				}
+
+				if (! isset($cosePubKey[-2] /* cose_crv_x */)) {
+					throw new Exception('cannot decode key response (10)');
+				}
+
+				if ($cosePubKey[-1] != 1 /* cose_crv_P256 */) {
+					throw new Exception('cannot decode key response (14)');
+				}
+
+				if (!isset($cosePubKey[-2] /* cose_crv_x */)) {
+					throw new Exception('x coordinate for curve missing');
+				}
+
+				if (! isset($cosePubKey[1] /* cose_kty */)) {
+					throw new Exception('cannot decode key response (7)');
+				}
+
+				if (! isset($cosePubKey[-3] /* cose_crv_y */)) {
+					throw new Exception('cannot decode key response (11)');
+				}
+
+				if (!isset($cosePubKey[-3] /* cose_crv_y */)) {
+					throw new Exception('y coordinate for curve missing');
+				}
+
+				if ($cosePubKey[1] != 2 /* cose_kty_ec2 */) {
+					throw new Exception('cannot decode key response (12)');
+				}
+
+				$x = $cosePubKey[-2]->get_byte_string();
+				$y = $cosePubKey[-3]->get_byte_string();
+				if (strlen($x) != 32 || strlen($y) != 32) {
+					throw new Exception('cannot decode key response (15)');
+				}
+
+				$tag = "\x04";
+
+				$pem = $this->pubkeyToPem($tag.$x.$y);
+
+				return $pem;
+
+			case self::RS256:
+				/* COSE Alg: RSASSA-PKCS1-v1_5 w/ SHA-256 */
+				if (!isset($cosePubKey[-2])) {
+					throw new Exception('RSA Exponent missing');
+				}
+				if (!isset($cosePubKey[-1])) {
+					throw new Exception('RSA Modulus missing');
+				}
+
+				$pubkey = $this->getRSAPubkey(
+					$cosePubKey[-2]->get_byte_string(),
+					$cosePubKey[-1]->get_byte_string()
+				);
+
+				return $pubkey;
+				//*/
+			default:
+				throw new Exception('cannot decode key response (13)');
+			}
+		}
+
+	/**
+	 *
+	 */
+	private function getRSAPubkey( $publicExponent, $modulus ) {
+		// derived from
+		$components = array(
+			'modulus' => pack('Ca*a*', 2, $this->derEncodeLength(strlen($modulus)), $modulus),
+			'publicExponent' => pack('Ca*a*', 2, $this->derEncodeLength(strlen($publicExponent)), $publicExponent)
+		);
+		$RSAPublicKey = pack(
+			'Ca*a*a*',
+			48, // ASN1 Sequence
+			$this->derEncodeLength(strlen($components['modulus']) + strlen($components['publicExponent'])),
+			$components['modulus'],
+			$components['publicExponent']
+		);
+
+		// sequence(oid(1.2.840.113549.1.1.1), null)) = rsaEncryption.
+		$rsaOID = pack('H*', '300d06092a864886f70d0101010500'); // hex version of MA0GCSqGSIb3DQEBAQUA
+		$RSAPublicKey = chr(0) . $RSAPublicKey;
+		$RSAPublicKey = chr(3) . $this->derEncodeLength(strlen($RSAPublicKey)) . $RSAPublicKey;
+
+		$RSAPublicKey = pack(
+			'Ca*a*',
+			48,
+			$this->derEncodeLength(strlen($rsaOID . $RSAPublicKey)),
+			$rsaOID . $RSAPublicKey
+		);
+
+		$RSAPublicKey = "-----BEGIN PUBLIC KEY-----\r\n" .
+						 chunk_split(base64_encode($RSAPublicKey), 64) .
+						 '-----END PUBLIC KEY-----';
+
+		return $RSAPublicKey;
+
+	}
+
+	/**
+	 *	DER-encode length
+	 *	{@link http://itu.int/ITU-T/studygroups/com17/languages/X.690-0207.pdf#p=13 X.690 paragraph 8.1.3}
+	 *
+	 *	@param Integer $length
+	 *	@param String DES Encoded $length
+	 */
+	private function derEncodeLength($length) {
+		if ($length <= 0x7F) {
+			return chr($length);
+		}
+
+		$temp = ltrim(pack('N', $length), chr(0));
+		return pack('Ca*', 0x80 | strlen($temp), $temp);
+
+	}
+
+
+	/**
+	 * shim for random_bytes which doesn't exist pre php7
+	 * @param int $length the number of bytes required
+	 * @return string cryptographically random bytes
+	 */
+	private static function randomBytes($length)
+	{
+		if (function_exists('random_bytes')) {
+			return random_bytes($length);
+		} else if (function_exists('openssl_random_pseudo_bytes')) {
+			$bytes = openssl_random_pseudo_bytes($length, $crypto_strong);
+			if (! $crypto_strong) {
+				throw new Exception("openssl_random_pseudo_bytes did not return a cryptographically strong result", 1);
+			}
+			return $bytes;
+		} else {
+			throw new Exception("Neither random_bytes not openssl_random_pseudo_bytes exists. PHP too old? openssl PHP extension not installed?", 1);
+		}
+	}
+
+
+}

--- a/providers/webauthn/includes/class-webauthn-keystore.php
+++ b/providers/webauthn/includes/class-webauthn-keystore.php
@@ -1,0 +1,141 @@
+<?php
+
+/**
+ *	Simple CRUD for keys
+ */
+class WebAuthnKeyStore {
+
+	const PUBKEY_USERMETA_KEY = '_two_factor_webauthn_pubkey';
+
+
+	/**
+	 * Array containing derived class instances
+	 */
+	private static $instance = null;
+
+	/**
+	 * Getting a singleton.
+	 *
+	 * @return object single instance of Core
+	 */
+	public static function instance() {
+
+		$class = get_called_class();
+
+		if ( is_null( self::$instance ) ) {
+			$args = func_get_args();
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 *	Prevent Instantinating
+	 */
+	private function __clone() { }
+
+	/**
+	 *	Protected constructor
+	 */
+	protected function __construct() {
+	}
+
+	/**
+	 * Get all keys for user
+	 *
+	 * @param int $user_id
+	 * @return array
+	 */
+	public function get_keys( $user_id ) {
+		return get_user_meta( $user_id, self::PUBKEY_USERMETA_KEY );
+	}
+
+	/**
+	 * Find specific key for user by
+	 *
+	 * @param int $user_id
+	 * @param string $keyLike
+	 * @return array|bool
+	 */
+	public function find_key( $user_id, $keyLike ) {
+		global $wpdb;
+
+		$found = $wpdb->get_results( $wpdb->prepare(
+			"SELECT * FROM $wpdb->usermeta WHERE user_id=%d AND meta_key=%s AND meta_value LIKE %s",
+			$user_id,
+			self::PUBKEY_USERMETA_KEY,
+			'%' . $wpdb->esc_like( $keyLike ) . '%'
+		) );
+		foreach ( $found as $key ) {
+			return maybe_unserialize( $key->meta_value );
+		}
+		return false;
+	}
+
+	/**
+	 * Check whether a key exists
+	 *
+	 * @param string $keyLike
+	 * @return bool
+	 */
+	public function key_exists( $keyLike ) {
+
+		global $wpdb;
+
+		$num_keys = $wpdb->get_var( $wpdb->prepare(
+			"SELECT COUNT(*) FROM $wpdb->usermeta WHERE meta_key=%s AND meta_value LIKE %s",
+			self::PUBKEY_USERMETA_KEY,
+			'%' . $wpdb->esc_like( serialize( $keyLike ) ) . '%'
+		) );
+
+		return intval( $num_keys ) !== 0;
+
+	}
+
+	/**
+	 * Add key to user
+	 *
+	 * @param int $user_id
+	 * @param string $key
+	 * @return bool
+	 */
+	public function create_key( $user_id, $key ) {
+		if ( $this->find_key( $user_id, $key->md5id ) ) {
+			return false;
+		}
+		return add_user_meta( $user_id, self::PUBKEY_USERMETA_KEY, $key );
+	}
+
+	/**
+	 * Add or update key for user
+	 *
+	 * @param int $user_id
+	 * @param string $key The new Key
+	 * @param string $keyLike The old Key to be updated
+	 * @return bool
+	 */
+	public function save_key( $user_id, $key, $keyLike ) {
+		$oldKey = $this->find_key( $user_id, $keyLike );
+		return update_user_meta( $user_id, self::PUBKEY_USERMETA_KEY, $key, $oldKey );
+	}
+
+	/**
+	 * Delete key for user
+	 *
+	 * @param int $user_id
+	 * @param string $keyLike The Key to be deleted
+	 * @return bool
+	 */
+	public function delete_key( $user_id, $keyLike ) {
+		global $wpdb;
+
+		if ( $key = $this->find_key( $user_id, $keyLike ) ) {
+			return delete_user_meta( $user_id, self::PUBKEY_USERMETA_KEY, $key );
+		}
+
+		return false;
+	}
+
+
+}

--- a/providers/webauthn/webauthn-admin.css
+++ b/providers/webauthn/webauthn-admin.css
@@ -1,0 +1,166 @@
+.webauth-register {
+	display: -webkit-box;
+	display: -ms-flexbox;
+	display: flex;
+	-webkit-box-align: center;
+	-ms-flex-align: center;
+	align-items: center;
+}
+.webauth-register .webauthn-error {
+	margin-left: 13px;
+}
+#webauthn-keys .busy,
+.webauth-register .busy {
+	color: #7f8284;
+	pointer-events: none;
+	-webkit-transition: opacity 0.3s ease;
+	-o-transition: opacity 0.3s ease;
+	transition: opacity 0.3s ease;
+	background-size: 30px 30px;
+	background-image: -o-linear-gradient(45deg, rgba(0, 0, 0, 0.1) 25%, transparent 25%, transparent 50%, rgba(0, 0, 0, 0.1) 50%, rgba(0, 0, 0, 0.1) 75%, transparent 75%, transparent);
+	background-image: linear-gradient(45deg, rgba(0, 0, 0, 0.1) 25%, transparent 25%, transparent 50%, rgba(0, 0, 0, 0.1) 50%, rgba(0, 0, 0, 0.1) 75%, transparent 75%, transparent);
+	-webkit-animation: barberpole 0.5s linear infinite;
+	animation: barberpole 0.5s linear infinite;
+}
+@-webkit-keyframes barberpole {
+	from {
+		background-position: 0 0;
+	}
+	to {
+		background-position: 60px 30px;
+	}
+}
+@keyframes barberpole {
+	from {
+		background-position: 0 0;
+	}
+	to {
+		background-position: 60px 30px;
+	}
+}
+.webauthn-key {
+	display: -webkit-box;
+	display: -ms-flexbox;
+	display: flex;
+	-ms-flex-wrap: wrap;
+	flex-wrap: wrap;
+	-webkit-box-align: last baseline;
+	-ms-flex-align: last baseline;
+	align-items: last baseline;
+	border-top: 1px solid #ccc;
+}
+@media screen and (max-width: 600px) {
+	.webauthn-key {
+		-webkit-box-orient: vertical;
+		-webkit-box-direction: normal;
+		-ms-flex-direction: column;
+		flex-direction: column;
+		text-align: center;
+	}
+	.webauthn-key > * {
+		min-width: 100%;
+		margin-bottom: 6px;
+	}
+}
+.webauthn-key,
+.webauthn-key * {
+	-webkit-box-sizing: border-box;
+	box-sizing: border-box;
+}
+.webauthn-key:last-of-type {
+	border-bottom: 1px solid #ccc;
+}
+.webauthn-key .webauthn-label {
+	-webkit-box-flex: 1;
+	-ms-flex: 1;
+	flex: 1;
+	white-space: normal;
+	padding: 3px;
+}
+@media screen and (max-width: 600px) {
+	.webauthn-key .webauthn-label {
+		font-size: 1.5em;
+		padding: 6px;
+	}
+}
+.webauthn-key .webauthn-label ~ * {
+	-webkit-box-flex: 0;
+	-ms-flex: 0;
+	flex: 0;
+}
+.webauthn-key .webauthn-created,
+.webauthn-key .webauthn-used {
+	display: inline-block;
+	white-space: nowrap;
+	padding: 0 0.5em;
+}
+@media screen and (min-width: 600px) {
+	.webauthn-key .webauthn-created,
+	.webauthn-key .webauthn-used {
+		min-width: 100px;
+	}
+}
+.webauthn-key [data-tested="tested"] {
+	color: #0085ba;
+}
+.webauthn-key [data-tested="fail"] {
+	color: #dc3232;
+}
+.webauthn-key [data-tested="fail"]::before {
+	content: "";
+}
+.webauthn-key [data-tested="untested"] {
+	color: #ccc;
+}
+.webauthn-key [data-tested="untested"]::before {
+	content: "";
+	border-radius: 50%;
+	border: 1px solid #ccc;
+	font-size: 16px;
+}
+.webauthn-key .webauthn-action {
+	padding: 3px;
+	border: 1px solid rgba(0, 0, 0, 0);
+	text-decoration: none;
+}
+.webauthn-key .webauthn-action-link {
+	-webkit-box-flex: 0;
+	-ms-flex: 0;
+	flex: 0;
+}
+.webauthn-key .webauthn-action-link.-test,
+.webauthn-key .webauthn-action-link.-delete {
+	white-space: nowrap;
+}
+@media screen and (max-width: 600px) {
+	.webauthn-key .webauthn-action-link.-test,
+	.webauthn-key .webauthn-action-link.-delete {
+		text-align: center;
+	}
+	.webauthn-key .webauthn-action-link.-test,
+	.webauthn-key .webauthn-action-link.-test ::before,
+	.webauthn-key .webauthn-action-link.-delete,
+	.webauthn-key .webauthn-action-link.-delete ::before {
+		font-size: 1.5em;
+	}
+}
+.webauthn-key .webauthn-action-link.-delete:hover {
+	color: #dc3232;
+}
+.webauthn-key > .webauthn-label {
+	word-break: break-word;
+}
+.webauthn-key > .webauthn-label:focus {
+	outline: none;
+}
+.webauthn-key > .webauthn-label[contenteditable="true"] {
+	background-color: #fff;
+	border-color: #0085ba;
+}
+.webauthn-key > .webauthn-label.busy {
+	border-color: #ccc;
+}
+.webauthn-key .notice {
+	-ms-flex-preferred-size: 100%;
+	flex-basis: 100%;
+}

--- a/providers/webauthn/webauthn-admin.js
+++ b/providers/webauthn/webauthn-admin.js
@@ -1,0 +1,370 @@
+( function( $ ) {
+
+	/**
+	 *	Borrowed from https://github.com/davidearl/webauthn
+	 */
+	function webauthnRegister( key, callback ) {
+
+		const publicKey = Object.assign( {}, key.publicKey );
+
+		publicKey.attestation = undefined;
+		publicKey.challenge = new Uint8Array( publicKey.challenge );
+		publicKey.user.id = new Uint8Array( publicKey.user.id );
+
+		navigator.credentials.create( { publicKey } )
+			.then( function( aNewCredentialInfo ) {
+				let cd, ao, rawId, info;
+
+				cd = JSON.parse( String.fromCharCode.apply( null, new Uint8Array( aNewCredentialInfo.response.clientDataJSON ) ) );
+				if ( key.b64challenge !== cd.challenge ) {
+					callback( false, 'key returned something unexpected (1)' );
+				}
+				if ( ! ( 'type' in cd ) ) {
+					return callback( false, 'key returned something unexpected (3)' );
+				}
+				if ( 'webauthn.create' != cd.type ) {
+					return callback( false, 'key returned something unexpected (4)' );
+				}
+
+				ao = [];
+				( new Uint8Array( aNewCredentialInfo.response.attestationObject ) ).forEach( function( v ) {
+					ao.push( v );
+				});
+				rawId = [];
+				( new Uint8Array( aNewCredentialInfo.rawId ) ).forEach( function( v ) {
+					rawId.push( v );
+				});
+				info = {
+					rawId: rawId,
+					id: aNewCredentialInfo.id,
+					type: aNewCredentialInfo.type,
+					response: {
+						attestationObject: ao,
+						clientDataJSON:
+						  JSON.parse( String.fromCharCode.apply( null, new Uint8Array( aNewCredentialInfo.response.clientDataJSON ) ) )
+					}
+				};
+				callback( true, JSON.stringify( info ) );
+			})
+			.catch( err => {
+				if ( 'name' in err ) {
+					callback( false, err.name + ': ' + err.message );
+				} else {
+					callback( false, err.toString() );
+				}
+			});
+	}
+
+	/**
+	 *	Borrowed from https://github.com/davidearl/webauthn
+	 */
+	function webauthnAuthenticate( pubKeyAuth, callback ) {
+
+		const originalChallenge = pubKeyAuth.challenge;
+		const pk = Object.assign( {}, pubKeyAuth );
+
+		pk.challenge = new Uint8Array( pubKeyAuth.challenge );
+		pk.allowCredentials = pk.allowCredentials.map( k => {
+			const ret = Object.assign( {}, k );
+			ret.id = new Uint8Array( k.id );
+			return ret;
+		} );
+
+		/* Ask the browser to prompt the user */
+		navigator.credentials.get( { publicKey: pk } )
+			.then( aAssertion => {
+				let ida, cd, cda, ad, sig, info;
+
+				ida = [];
+				( new Uint8Array( aAssertion.rawId ) ).forEach( function( v ) {
+					ida.push( v );
+				} );
+
+				cd = JSON.parse( String.fromCharCode.apply( null,
+															  new Uint8Array( aAssertion.response.clientDataJSON ) ) );
+
+				cda = [];
+				( new Uint8Array( aAssertion.response.clientDataJSON ) ).forEach( function( v ) {
+					cda.push( v );
+				} );
+
+				ad = [];
+				( new Uint8Array( aAssertion.response.authenticatorData ) ).forEach( function( v ) {
+					ad.push( v );
+				} );
+
+				sig = [];
+				( new Uint8Array( aAssertion.response.signature ) ).forEach( function( v ) {
+					sig.push( v );
+				} );
+
+				info = {
+					type: aAssertion.type,
+					originalChallenge: originalChallenge,
+					rawId: ida,
+					response: {
+						authenticatorData: ad,
+						clientData: cd,
+						clientDataJSONarray: cda,
+						signature: sig
+					}
+				};
+
+				callback( true, JSON.stringify( info ) );
+			})
+			.catch( err => {
+				/*
+				FF mac:
+				InvalidStateError: key not found
+				AbortError: user aborted or denied
+				NotAllowedError: ?
+					The request is not allowed by the user agent or the platform in the current context, possibly because the user denied permission.
+
+				Chrome mac:
+				NotAllowedError: user aborted or denied
+
+				Safari mac:
+				NotAllowedError: user aborted or denied
+
+				Edge win10:
+				UnknownError: wrong key...?
+				NotAllowedError: user aborted or denied
+
+				FF win:
+				NotAllowedError: user aborted or denied
+					DOMException: "The request is not allowed by the user agent or the platform in the current context, possibly because the user denied permission."
+				*/
+				if ( 'name' in err ) {
+					callback( false, err.name + ': ' + err.message );
+				} else {
+					callback( false, err.toString() );
+				}
+			});
+	};
+
+	/**
+	 *	@param ArrayBuffer arrayBuf
+	 *	@return Array
+	 */
+	const buffer2Array = arrayBuf => [ ... ( new Uint8Array( arrayBuf ) ) ];
+
+	const register = ( opts, callback ) => {
+
+		const { action, userId, payload, _wpnonce } = opts;
+
+		webauthnRegister( payload, ( success, info ) => {
+			if ( success ) {
+				$.ajax({
+					url: wp.ajax.settings.url,
+					method: 'post',
+					data: {
+						action,
+						payload: info,
+						user_id: userId,
+						_wpnonce
+					},
+					success: callback
+				});
+			} else {
+				callback( { success: false, message: info } );
+			}
+		} );
+	};
+
+	const login = ( opts, callback ) => {
+
+		const { action, payload, _wpnonce } = opts;
+
+		webauthnAuthenticate( payload, ( success, info ) => {
+			if ( success ) {
+				callback( { success:true, result: info } );
+			} else {
+				callback( { success:false, message: info } );
+			}
+		});
+	};
+
+	const sendRequest = ( opts, callback ) => {
+
+		$.ajax( {
+			url: wp.ajax.settings.url,
+			method: 'post',
+			data: opts,
+			success:callback
+		} );
+	};
+
+	const editKey = ( editLabel, opts, callback = () => {} ) => {
+
+		const {
+			action,
+			payload,
+			_wpnonce,
+			userId
+		} = opts;
+
+		const stopEditing = ( save = false ) => {
+			const newLabel = $( editLabel ).text();
+			$( editLabel ).text( newLabel );
+			$( editLabel ).prop( 'contenteditable', false );
+			$( document ).off( 'keydown' );
+			$( editLabel ).off( 'blur' );
+			if ( save && prevLabel !== newLabel ) {
+				$( editLabel ).addClass( 'busy' );
+
+				sendRequest(
+					{
+						action,
+						payload: {
+							md5id: payload,
+							label: newLabel
+						},
+						user_id: userId,
+						_wpnonce
+					},
+					response => {
+						$( editLabel ).removeClass( 'busy' );
+						callback( response );
+					}
+				);
+			} else if ( ! save ) {
+				$( editLabel ).text( prevLabel );
+			}
+		};
+
+		const prevLabel = $( editLabel ).text();
+
+		$( editLabel ).prop( 'contenteditable', true );
+
+		$( document ).on( 'keydown', e => {
+			if ( 13 === e.which ) {
+				stopEditing( true );
+				e.preventDefault();
+			} else if ( 27 === e.which ) {
+				stopEditing( true );
+			}
+		} );
+
+		// Focus and select
+		$( editLabel )
+			.on( 'blur', e => stopEditing( true ) )
+			.on( 'paste', e => {
+				e.preventDefault();
+				let text = ( e.originalEvent || e ).clipboardData.getData( 'text/plain' );
+				document.execCommand( 'insertHTML', false, text );
+			} );
+
+		$( editLabel ).focus();
+
+		document.execCommand( 'selectAll', false, null );
+	};
+
+	$( document ).on( 'click', '#webauthn-register-key', e => {
+
+		e.preventDefault();
+
+		$( e.target ).next( '.webauthn-error' ).remove();
+
+		const $btn = $( e.target ).addClass( 'busy' );
+
+		const opts = JSON.parse( $( e.target ).attr( 'data-create-options' ) );
+
+		register( opts, response => {
+			$btn.removeClass( 'busy' );
+			if ( response.success ) {
+				const $keyItem = $( response.html ).appendTo( '#webauthn-keys' );
+				const $keyLabel = $keyItem.find( '.webauthn-label' );
+
+				editKey(
+					$keyLabel.get( 0 ),
+					JSON.parse( $keyLabel.attr( 'data-action' ) )
+				);
+			} else {
+				let msg;
+				if ( !! response.message ) {
+					msg = response.message;
+				} else if ( !! response.data && response.data[0] && response.data[0].message ) {
+					msg = response.data[0].message;
+				} else {
+					msg = JSON.stringify( response );
+				}
+				$( `<span class="webauthn-error description">${msg}</span>` ).insertAfter( '#webauthn-register-key' );
+			}
+		});
+
+	});
+
+	if ( 'credentials' in navigator ) {
+		$( document ).on( 'click', '.webauthn-action', e => {
+			e.preventDefault();
+			const $btn = $( e.target ).closest( '.webauthn-action' );
+			const opts = JSON.parse( $btn.attr( 'data-action' ) );
+			const $keyEl = $( e.target ).closest( '.webauthn-key' );
+			const {
+				action,
+				userId,
+				payload,
+				_wpnonce
+			} = opts;
+
+
+			if ( 'webauthn-test-key' === action ) {
+				e.preventDefault();
+				$keyEl.find( '.notice' ).remove();
+				$btn.addClass( 'busy' );
+				login( opts, result => {
+					if ( ! result.success ) {
+						$keyEl.append( `<div class="notice notice-inline notice-warning">${result.message}</div>` );
+						$btn.removeClass( 'busy' );
+						return;
+					}
+
+					// Send to server
+					sendRequest( {
+						action,
+						user_id: userId,
+						payload: result.result,
+						_wpnonce
+					}, response => {
+						if ( response.success ) {
+							$btn.find( '[data-tested]' ).attr( 'data-tested', 'tested' );
+						} else {
+							$btn.find( '[data-tested]' ).attr( 'data-tested', 'fail' );
+							$keyEl.append( `<div class="notice notice-inline notice-error">${response.data[0].message}</div>` );
+						}
+						$btn.removeClass( 'busy' );
+					} );
+				} );
+			} else if ( 'webauthn-delete-key' === action ) {
+				$keyEl.addClass( 'busy' );
+				e.preventDefault();
+				sendRequest( opts, function( response ) {
+					$keyEl.removeClass( 'busy' );
+
+					// Remove key from list
+					if ( response.success ) {
+						$keyEl.remove();
+					} else {
+
+						// Error from server
+						$keyEl.append( `<div class="notice notice-inline notice-error">${response.data[0].message}</div>` );
+					}
+				} );
+			}
+			if ( 'webauthn-edit-key' === opts.action ) {
+				if ( 'true' !== $( e.currentTarget ).prop( 'contenteditable' ) ) {
+					e.preventDefault();
+					editKey( e.currentTarget, opts, response => {
+						if ( ! response.success ) {
+							$keyEl.append( `<div class="notice notice-inline notice-error">${response.data[0].message}</div>` );
+						}
+					} );
+				}
+			}
+		} );
+	} else {
+		$( '.webauthn-unsupported' ).removeClass( 'hidden' );
+		$( '.webauthn-supported' ).addClass( 'hidden' );
+	}
+
+} )( jQuery );

--- a/providers/webauthn/webauthn-login.css
+++ b/providers/webauthn/webauthn-login.css
@@ -1,0 +1,16 @@
+.webauthn-retry,
+.webauthn-unsupported {
+	display:none;
+	margin-top:13px;
+}
+.webauthn-retry.visible,
+.webauthn-unsupported.visible{
+	display:block;
+}
+.webauthn-retry p,
+.webauthn-unsupported p {
+	font-style:italic;
+}
+.webauthn-retry .button{
+	float:right;
+}

--- a/providers/webauthn/webauthn-login.js
+++ b/providers/webauthn/webauthn-login.js
@@ -1,0 +1,114 @@
+( function( $ ) {
+	/**
+	 *	Borrowed from https://github.com/davidearl/webauthn
+	 */
+	function webauthnAuthenticate( pubKeyAuth, callback ) {
+
+		const originalChallenge = pubKeyAuth.challenge;
+		const pk = Object.assign( {}, pubKeyAuth );
+
+		pk.challenge = new Uint8Array( pubKeyAuth.challenge );
+		pk.allowCredentials = pk.allowCredentials.map( k => {
+			const ret = Object.assign( {}, k );
+			ret.id = new Uint8Array( k.id );
+			return ret;
+		} );
+
+		/* Ask the browser to prompt the user */
+		navigator.credentials.get( { publicKey: pk } )
+			.then( aAssertion => {
+				let ida, cd, cda, ad, sig, info;
+
+				ida = [];
+				( new Uint8Array( aAssertion.rawId ) ).forEach( function( v ) {
+					ida.push( v );
+				} );
+
+				cd = JSON.parse( String.fromCharCode.apply( null,
+															  new Uint8Array( aAssertion.response.clientDataJSON ) ) );
+
+				cda = [];
+				( new Uint8Array( aAssertion.response.clientDataJSON ) ).forEach( function( v ) {
+					cda.push( v );
+				} );
+
+				ad = [];
+				( new Uint8Array( aAssertion.response.authenticatorData ) ).forEach( function( v ) {
+					ad.push( v );
+				} );
+
+				sig = [];
+				( new Uint8Array( aAssertion.response.signature ) ).forEach( function( v ) {
+					sig.push( v );
+				} );
+
+				info = {
+					type: aAssertion.type,
+					originalChallenge: originalChallenge,
+					rawId: ida,
+					response: {
+						authenticatorData: ad,
+						clientData: cd,
+						clientDataJSONarray: cda,
+						signature: sig
+					}
+				};
+
+				callback( true, JSON.stringify( info ) );
+			})
+			.catch( err => {
+				if ( 'name' in err ) {
+					callback( false, err.name + ': ' + err.message );
+				} else {
+					callback( false, err.toString() );
+				}
+			});
+	};
+
+	const login = ( opts, callback ) => {
+
+		const { action, payload, _wpnonce } = opts;
+
+		webauthnAuthenticate( payload, ( success, info ) => {
+			if ( success ) {
+				callback( { success:true, result: info } );
+			} else {
+				callback( { success:false, message: info } );
+			}
+		});
+	};
+
+	/**
+	 *	Some Password Managers (like nextcloud passwords) seem to abort the
+	 *	key browser dialog.
+	 *	We have to retry a couple of times to
+	 */
+	const auth = () => {
+		$( '.webauthn-retry' ).removeClass( 'visible' );
+		login( window.webauthnL10n, response => {
+			if ( response.success ) {
+				$( '#webauthn_response' ).val( response.result );
+				$( '#loginform' ).submit();
+			} else {
+
+				// Show retry-button
+				$( '.webauthn-retry' ).addClass( 'visible' );
+			}
+		} );
+	};
+
+	if ( ! window.webauthnL10n ) {
+		console.error( 'webauthL10n is not defined' );
+	};
+
+	if ( 'credentials' in navigator ) {
+		$( document )
+			.ready( auth )
+			.on( 'click', '.webauthn-retry-link', auth );
+	} else {
+
+		// Show unsupported message
+		$( '.webauthn-unsupported' ).addClass( 'visible' );
+	}
+
+} )( jQuery );

--- a/settings/settings.php
+++ b/settings/settings.php
@@ -25,10 +25,15 @@ function register_block() {
  * @codeCoverageIgnore
  */
 function replace_core_ui_with_custom() : void {
+	/*
+	@todo Temporarily commented so that WebAuthn can be managed via wp-admin. Restore this when our custom WebAuthn UI is ready.
+	See https://github.com/WordPress/wporg-two-factor/issues/114, https://github.com/WordPress/wporg-two-factor/issues/87.
+
 	remove_action( 'show_user_profile', array( 'Two_Factor_Core', 'user_two_factor_options' ) );
 	remove_action( 'edit_user_profile', array( 'Two_Factor_Core', 'user_two_factor_options' ) );
 	remove_action( 'personal_options_update', array( 'Two_Factor_Core', 'user_two_factor_options_update' ) );
 	remove_action( 'edit_user_profile_update', array( 'Two_Factor_Core', 'user_two_factor_options_update' ) );
+	*/
 
 	add_action( 'bbp_user_edit_account', __NAMESPACE__ . '\render_custom_ui' );
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -40,6 +40,7 @@ function _manually_load_plugin() {
 	// Mimic w.org capes.php.
 	$GLOBALS['super_admins'] = array();
 
+	require_once dirname( __DIR__, 3 ) . '/mu-plugins/pub/mu-plugins/loader.php';
 	require dirname( __DIR__, 2 ) . '/two-factor/two-factor.php';
 	require dirname( __DIR__ ) . '/wporg-two-factor.php';
 }

--- a/tests/providers/test-class-two-factor-webauthn.php
+++ b/tests/providers/test-class-two-factor-webauthn.php
@@ -84,7 +84,7 @@ kTim0qBEAjJ1pJODE9/HH/1sPjDQqC3urY2rnzvxwdkDxeSEWHMmMyYjdA==
 	/**
 	 * Verify the label value.
 	 *
-	 * @covers Two_Factor_WebAuthn::test_get_label
+	 * @covers Two_Factor_WebAuthn::get_label
 	 */
 	public function test_get_label() {
 		$this->assertStringContainsString( 'Web Authentication (FIDO2)', $this->provider->get_label() );

--- a/tests/providers/test-class-two-factor-webauthn.php
+++ b/tests/providers/test-class-two-factor-webauthn.php
@@ -1,0 +1,200 @@
+<?php
+
+/**
+ * Class Tests_Two_Factor_WebAuthn
+ *
+ * @group webauthn
+ */
+class Tests_Two_Factor_WebAuthn extends WP_UnitTestCase {
+
+	private $registration_payload = '{
+		"rawId":[87,80,104,99,114,105,242,93,228,236,13,229,38,46,106,28,137,148,253,93,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],
+		"id":"V1BoY3Jp8l3k7A3lJi5qHImU_V0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"type":"public-key",
+		"response":{
+			"attestationObject":[163,99,102,109,116,100,110,111,110,101,103,97,116,116,83,116,109,116,160,104,97,117,116,104,68,97,116,97,88,202,8,99,119,173,50,147,45,217,178,80,98,28,172,142,22,49,31,86,54,121,220,23,215,66,25,115,254,227,13,103,50,169,65,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,70,87,80,104,99,114,105,242,93,228,236,13,229,38,46,106,28,137,148,253,93,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,165,1,2,3,38,32,1,33,88,32,206,171,161,194,131,117,59,237,98,52,69,222,8,194,112,14,210,10,32,118,244,130,91,255,194,88,250,26,133,232,251,7,34,88,32,174,88,49,78,229,69,143,60,4,230,24,208,109,254,244,17,52,112,247,80,35,164,106,111,124,233,54,235,59,88,186,130],
+			"clientDataJSON":{
+				"challenge":"blJGueerd0LwM-L0SL7F_w",
+				"origin":"https://mu.wordpress.local",
+				"type":"webauthn.create"
+			}
+		}
+	}';
+
+	private $authentication_payload = '{
+		"type":"public-key",
+		"originalChallenge":[217,231,76,191,26,145,184,220,67,97,132,111,2,171,201,47],
+		"rawId":[67,54,58,166,42,6,98,53,38,200,37,88,228,35,173,43,86,61,67,158,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],
+		"response":{
+			"authenticatorData":[8,99,119,173,50,147,45,217,178,80,98,28,172,142,22,49,31,86,54,121,220,23,215,66,25,115,254,227,13,103,50,169,1,0,0,3,23],
+			"clientData":{
+				"challenge":"2edMvxqRuNxDYYRvAqvJLw",
+				"origin":"https://mu.wordpress.local",
+				"type":"webauthn.get"
+			},
+			"clientDataJSONarray":[123,34,99,104,97,108,108,101,110,103,101,34,58,34,50,101,100,77,118,120,113,82,117,78,120,68,89,89,82,118,65,113,118,74,76,119,34,44,34,111,114,105,103,105,110,34,58,34,104,116,116,112,115,58,47,47,109,117,46,119,111,114,100,112,114,101,115,115,46,108,111,99,97,108,34,44,34,116,121,112,101,34,58,34,119,101,98,97,117,116,104,110,46,103,101,116,34,125],
+			"signature":[48,70,2,33,0,192,248,68,123,255,29,98,208,114,247,171,154,176,238,228,181,57,101,151,216,236,13,185,55,135,38,86,145,250,147,48,194,2,33,0,193,141,246,5,72,138,5,201,224,30,37,184,43,172,29,84,244,85,35,107,183,27,203,246,96,214,149,180,229,145,77,30]
+		}
+	}';
+
+	private $serialized_key = 'O:8:"stdClass":7:{s:3:"key";s:178:"-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAENWyfR/Dv24yoxFxHQAWulCHn6OO7
+kTim0qBEAjJ1pJODE9/HH/1sPjDQqC3urY2rnzvxwdkDxeSEWHMmMyYjdA==
+-----END PUBLIC KEY-----
+";s:2:"id";a:70:{i:0;i:67;i:1;i:54;i:2;i:58;i:3;i:166;i:4;i:42;i:5;i:6;i:6;i:98;i:7;i:53;i:8;i:38;i:9;i:200;i:10;i:37;i:11;i:88;i:12;i:228;i:13;i:35;i:14;i:173;i:15;i:43;i:16;i:86;i:17;i:61;i:18;i:67;i:19;i:158;i:20;i:0;i:21;i:0;i:22;i:0;i:23;i:0;i:24;i:0;i:25;i:0;i:26;i:0;i:27;i:0;i:28;i:0;i:29;i:0;i:30;i:0;i:31;i:0;i:32;i:0;i:33;i:0;i:34;i:0;i:35;i:0;i:36;i:0;i:37;i:0;i:38;i:0;i:39;i:0;i:40;i:0;i:41;i:0;i:42;i:0;i:43;i:0;i:44;i:0;i:45;i:0;i:46;i:0;i:47;i:0;i:48;i:0;i:49;i:0;i:50;i:0;i:51;i:0;i:52;i:0;i:53;i:0;i:54;i:0;i:55;i:0;i:56;i:0;i:57;i:0;i:58;i:0;i:59;i:0;i:60;i:0;i:61;i:0;i:62;i:0;i:63;i:0;i:64;i:0;i:65;i:0;i:66;i:0;i:67;i:0;i:68;i:0;i:69;i:0;}s:5:"label";s:31:"New Device - mu.wordpress.local";s:5:"md5id";s:32:"8b8c94e8772035976355b604571c29a6";s:7:"created";i:1667479980;s:9:"last_used";b:0;s:6:"tested";b:1;}';
+
+	/**
+	 * Instance of our provider class.
+	 *
+	 * @var Two_Factor_WebAuthn
+	 */
+	protected $provider;
+
+	/**
+	 * Set up a test case.
+	 *
+	 * @see WP_UnitTestCase::setup()
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->provider = Two_Factor_WebAuthn::get_instance();
+	}
+
+	/**
+	 * Clean up after tests.
+	 *
+	 * @see WP_UnitTestCase::tearDown()
+	 */
+	public function tearDown(): void {
+		unset( $this->provider );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Verify an instance exists.
+	 *
+	 * @covers Two_Factor_Totp::get_instance
+	 */
+	public function test_get_instance() {
+		$this->assertNotNull( $this->provider->get_instance() );
+	}
+
+	/**
+	 * Verify the label value.
+	 *
+	 * @covers Two_Factor_WebAuthn::test_get_label
+	 */
+	public function test_get_label() {
+		$this->assertStringContainsString( 'Web Authentication (FIDO2)', $this->provider->get_label() );
+	}
+
+	/**
+	 * Verify appi id is a valid hostname
+	 *
+	 * @covers Two_Factor_WebAuthn::get_app_id
+	 */
+	public function test_get_app_id() {
+
+		$app_id = $this->provider->get_app_id();
+
+		// whether this is a valid hostname
+		$this->assertIsString( filter_var( $app_id, FILTER_VALIDATE_DOMAIN, FILTER_NULL_ON_FAILURE ) );
+
+		// the key is part of the current wp hostname
+		$this->assertStringContainsString( $app_id, get_option('home') );
+
+	}
+
+	/**
+	 * @covers Two_Factor_WebAuthn::validate_authentication
+	 */
+	public function test_validate_authentication() {
+
+		$user_id = $this->factory->user->create();
+		$user = new WP_User( $user_id );
+
+		$key = unserialize( $this->serialized_key );
+
+		$key_store = WebAuthnKeyStore::instance();
+
+		add_user_meta( $user_id, '_two_factor_enabled_providers', array( 'Two_Factor_WebAuthn' ) );
+		add_user_meta( $user_id, '_two_factor_provider', 'Two_Factor_WebAuthn' );
+
+		$key_store->save_key( $user_id, $key, $key->md5id );
+
+		// test non-json response
+		$_POST['webauthn_response'] = '-- garbage --';
+
+		$result = $this->provider->validate_authentication( $user );
+		$this->assertFalse( $result );
+
+
+		// test successful authentication
+		// keys are domain specific. We are testing actual keys, so we can't simply use a dummy host here
+		$webauthn = new WebAuthnHandler( 'mu.wordpress.local' );
+		$result = $webauthn->authenticate( json_decode( $this->authentication_payload ), $key_store->get_keys( $user_id ) );
+		// craft a request, try to verify
+		$this->assertIsObject( $result ); // dummy
+
+
+		// test key deletion
+		$key_store->delete_key( $user_id, $key->md5id );
+		$result = $key_store->find_key( $user_id, $key->md5id );
+		$this->assertFalse( $result );
+
+		$result = $webauthn->authenticate( json_decode( $this->authentication_payload ), $key_store->get_keys( $user_id ) );
+		// craft a request, try to verify
+		$this->assertFalse( $result ); // dummy
+
+	}
+
+	/**
+	 * @covers Two_Factor_WebAuthn::ajax_register
+	 */
+	public function test_register() {
+		add_filter( 'wp_die_ajax_handler', function( $handler ) { return '__return_false'; } );
+		add_filter( 'wp_ajax_handler', function() { return '__return_false'; } );
+
+		$user_id = $this->factory->user->create();
+		$user = new WP_User( $user_id );
+
+		$webauthn = new WebAuthnHandler( 'mu.wordpress.local' );
+		$key_store = WebAuthnKeyStore::instance();
+
+		$credential = json_decode( $this->registration_payload );
+
+		$key = $webauthn->register( $credential, '' );
+
+		$this->assertIsObject( $key );
+
+		/* translators: %s webauthn app id (domain) */
+		$key->label     = sprintf( esc_html__( 'New Device - %s', 'two-factor' ), $this->provider->get_app_id() );
+		$key->md5id     = md5( implode( '', array_map( 'chr', $key->id ) ) );
+		$key->created   = time();
+		$key->last_used = false;
+		$key->tested    = false;
+
+		$meta_id = $key_store->save_key( $user_id, $key, $key->md5id );
+
+		$this->assertIsInt( $meta_id );
+
+		// save the same key again
+		$key->label = 'name was changed';
+		$alternative_meta_id = $key_store->save_key( $user_id, $key, $key->md5id );
+
+		$this->assertEquals( $meta_id, $alternative_meta_id );
+
+
+		// try to save the same key again
+		$new_meta_id = $key_store->create_key( $user_id, $key );
+
+		$this->assertFalse( $new_meta_id );
+
+		$keys = $key_store->get_keys( $user_id );
+		$this->assertEquals( count( $keys ), 1 );
+
+	}
+
+}

--- a/wporg-two-factor.php
+++ b/wporg-two-factor.php
@@ -26,7 +26,6 @@ function is_2fa_beta_tester() : bool {
 	return in_array( $user->user_login, $beta_testers, true );
 }
 
-require_once __DIR__ . '/providers/webauthn/class-two-factor-webauthn.php';
 require_once __DIR__ . '/settings/settings.php';
 
 add_filter( 'two_factor_providers', __NAMESPACE__ . '\two_factor_providers', 99 ); // Must run _after_ all other plugins.
@@ -41,6 +40,8 @@ add_action( 'user_has_cap', __NAMESPACE__ . '\remove_capabilities_until_2fa_enab
  * Determine which providers should be available to users.
  */
 function two_factor_providers( array $providers ) : array {
+	require_once __DIR__ . '/providers/webauthn/class-two-factor-webauthn.php';
+
 	// Match the name => file path format of input var, but the path isn't needed.
 	$desired_providers = array(
 		'Two_Factor_Totp'         => '',


### PR DESCRIPTION
See #114

This forks the provider from https://github.com/WordPress/two-factor/pull/427/ as starting point for our customized version of it. More work will be needed to close that issue, but I'm planning to do it across several PRs to keep it manageable.

This one just forks the upstream PR and gets it working inside our plugin. Future PRs will migrate to the MadWizard library, remove abstractions, increase test coverage, and make other changes to fit w.org's needs. After we refine everything, we can eventually contribute it upstream as an alternate proposal.

A lot of this will be removed or changed significantly in the following PRs, so the only parts that are really worth reviewing are:

* `phpunit.xml.dist`
* `wporg-two-factor.php`
* `providers/webauthn/class-two-factor-webauthn.php`
* `providers/webauthn/webauthn-admin.js`
* `providers/webauthn/webauthn-login.js`
* `providers/webauthn/webauthn-login.js`
