### PR TITLE
Clear incomplete state when navigating away page

### DIFF
--- a/settings/src/components/password.js
+++ b/settings/src/components/password.js
@@ -40,6 +40,9 @@ export default function Password() {
 	const [ inputType, setInputType ] = useState( 'password' );
 	const [ hasAttemptedSave, setHasAttemptedSave ] = useState( false );
 	let passwordStrong = true; // Saved passwords have already passed the test.
+	// Originally, password wasn't set in record, but we need it to be an empty string for 
+	// resetting to initial after navigating away from password setting page.
+	userRecord.record.password = '';
 
 	if ( userRecord.hasEdits ) {
 		passwordStrong = isPasswordStrong(

--- a/settings/src/components/password.js
+++ b/settings/src/components/password.js
@@ -40,9 +40,6 @@ export default function Password() {
 	const [ inputType, setInputType ] = useState( 'password' );
 	const [ hasAttemptedSave, setHasAttemptedSave ] = useState( false );
 	let passwordStrong = true; // Saved passwords have already passed the test.
-	// Originally, password wasn't set in record, but we need it to be an empty string for 
-	// resetting to initial after navigating away from password setting page.
-	userRecord.record.password = '';
 
 	if ( userRecord.hasEdits ) {
 		passwordStrong = isPasswordStrong(

--- a/settings/src/components/tests/password/password.test.js
+++ b/settings/src/components/tests/password/password.test.js
@@ -80,7 +80,7 @@ describe( 'Password', () => {
 			expect( queryAllByText( strongPasswordRegex ) ).toHaveLength( 0 );
 		} );
 
-		it( 'should display the weak password notice', () => {
+		it( 'should display the weak password notice after submitting', () => {
 			// State: the user has updated their password to something weak
 			// although the strength is not tested here.
 			mockContext.userRecord.editedRecord.password = 'weak';
@@ -91,13 +91,20 @@ describe( 'Password', () => {
 			// We'll mock the password estimator to return a score of 1.
 			mockPasswordEstimator( 1 );
 
-			const { queryAllByText } = render( <Password />, {
+			const { queryAllByText, getAllByRole } = render( <Password />, {
 				wrapper: ( { children } ) => (
 					<GlobalContext.Provider value={ mockContext }>
 						{ children }
 					</GlobalContext.Provider>
 				),
 			} );
+
+			// Find the submit button and click it.
+			const buttons = getAllByRole( 'button' );
+			const saveButton = buttons.filter(
+				( button ) => button.type === 'submit'
+			)[ 0 ];
+			fireEvent.click( saveButton );
 
 			// We may have this message multiple times, because of 'speak'.
 			expect(

--- a/settings/src/components/tests/utlitites.test.js
+++ b/settings/src/components/tests/utlitites.test.js
@@ -1,0 +1,88 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { useEntityRecord } from '@wordpress/core-data';
+
+/**
+ * Local dependencies
+ */
+import { getUserRecord, refreshRecord } from '../../utilities';
+
+jest.mock('@wordpress/data');
+jest.mock('@wordpress/core-data');
+
+describe('getUserRecord', () => {
+    beforeEach(() => {
+        useSelect.mockClear();
+        useEntityRecord.mockClear();
+    });
+
+    it('should call useEntityRecord with correct arguments', () => {
+        useEntityRecord.mockReturnValue({ record: {} });
+
+        getUserRecord(1);
+
+        expect(useEntityRecord).toHaveBeenCalledWith('root', 'user', 1);
+    });
+
+    it('should set isSaving in userRecord if not defined', () => {
+        useEntityRecord.mockReturnValue({ record: {} });
+        useSelect.mockReturnValue(true);
+
+        const result = getUserRecord(1);
+
+        expect(result.isSaving).toBeTruthy();
+        expect(useSelect).toHaveBeenCalled();
+    });
+
+    it('should not set isSaving in userRecord if already defined', () => {
+        useEntityRecord.mockReturnValue({ record: {}, isSaving: false });
+        useSelect.mockReturnValue(true);
+
+        const result = getUserRecord(1);
+
+        expect(result.isSaving).toBeFalsy();
+        expect(useSelect).not.toHaveBeenCalled();
+    });
+
+    it('should initialize password in userRecord.record if not defined', () => {
+        useEntityRecord.mockReturnValue({ record: {} });
+
+        const result = getUserRecord(1);
+
+        expect(result.record.password).toBe('');
+    });
+
+    it('should not overwrite password in userRecord.record if already defined', () => {
+        useEntityRecord.mockReturnValue({ record: { password: 'test-password' } });
+
+        const result = getUserRecord(1);
+
+        expect(result.record.password).toBe('test-password');
+    });
+});
+
+describe('refreshRecord', () => {
+  let mockRecord;
+
+  beforeEach(() => {
+    mockRecord = {
+      edit: jest.fn(),
+      save: jest.fn(),
+    };
+  });
+
+  afterEach(() => {
+    mockRecord.edit.mockReset();
+    mockRecord.save.mockReset();
+  });
+
+  it('should call edit and save methods on the record object', () => {
+    refreshRecord(mockRecord);
+
+    expect(mockRecord.edit).toHaveBeenCalledWith({ refreshRecordFakeKey: '' });
+    expect(mockRecord.save).toHaveBeenCalled();
+  });
+});
+

--- a/settings/src/script.js
+++ b/settings/src/script.js
@@ -95,9 +95,6 @@ function Main( { userId } ) {
 		event.preventDefault();
 
 		// Reset to initial after navigating away from a page.
-		// @todo This no longer works, maybe `userRecord` is not passed by reference between screens?
-		// Also, some screens will have additional state that should be reset, but this won't have any way of
-		// knowing that. So maybe just remove this?
 		if ( hasEdits ) {
 			edit( record );
 		}

--- a/settings/src/utilities.js
+++ b/settings/src/utilities.js
@@ -12,6 +12,11 @@ export function getUserRecord( userId ) {
 		userRecord.isSaving = useSelect( ( select ) => select( coreDataStore ).isSavingEntityRecord( 'root', 'user', userId ) );
 	}
 
+	// Initialize the password as an empty string, necessary for resetting incomplete state when leaving the password setting page.
+	if ( userRecord.record && undefined === userRecord.record.password ) {
+		userRecord.record.password = '';
+	}
+
 	return userRecord;
 }
 


### PR DESCRIPTION
Fixes #117

This PR clears the incomplete state when navigating away from the password setting page.

![password](https://user-images.githubusercontent.com/18050944/234407623-b7725246-8779-4a35-aacf-97df2ea8102c.gif)
