### PR TITLE
Enable-2FA notice shown when already setup

### DIFF
--- a/wporg-two-factor.php
+++ b/wporg-two-factor.php
@@ -114,7 +114,7 @@ function remove_super_admins_until_2fa_enabled() : void {
  * perform privileged actions on the front end, via the REST API, etc.
  */
 function remove_capabilities_until_2fa_enabled( array $allcaps, array $caps, array $args, WP_User $user ) : array {
-	if ( 0 === $user->ID || ! user_requires_2fa( $user ) ) {
+	if ( 0 === $user->ID || $user->ID !== get_current_user_id() || ! user_requires_2fa( $user ) ) {
 		return $allcaps;
 	}
 


### PR DESCRIPTION
remove_capabilities_until_2fa_enabled() doesn't verify that the accounts capabilities being filtered is the current user, as a result, running `user_can( $other_user, 'admin_only_cap' )` will cause this plugin to add the enable-2fa notice.



- [ ] Unit tests