### PR TITLE
Enable WebAuthn plugin in wp-admin

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -3,8 +3,8 @@
 		".",
 		"https://downloads.wordpress.org/plugin/gutenberg.latest-stable.zip",
 		"https://downloads.wordpress.org/plugin/bbpress.latest-stable.zip",
-		"https://downloads.wordpress.org/plugin/two-factor-provider-webauthn.latest-stable.zip",
-		"WordPress/two-factor"
+		"WordPress/two-factor",
+		"https://downloads.wordpress.org/plugin/two-factor-provider-webauthn.latest-stable.zip"
 	],
 	"mappings": {
 		"wp-content/themes/wporg-support": "WordPress/wordpress.org/wordpress.org/public_html/wp-content/themes/pub/wporg-support/",

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -3,6 +3,7 @@
 		".",
 		"https://downloads.wordpress.org/plugin/gutenberg.latest-stable.zip",
 		"https://downloads.wordpress.org/plugin/bbpress.latest-stable.zip",
+		"https://downloads.wordpress.org/plugin/two-factor-provider-webauthn.latest-stable.zip",
 		"WordPress/two-factor"
 	],
 	"mappings": {

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,10 +1,10 @@
 {
 	"plugins": [
-		".",
 		"https://downloads.wordpress.org/plugin/gutenberg.latest-stable.zip",
 		"https://downloads.wordpress.org/plugin/bbpress.latest-stable.zip",
 		"WordPress/two-factor",
-		"https://downloads.wordpress.org/plugin/two-factor-provider-webauthn.latest-stable.zip"
+		"https://downloads.wordpress.org/plugin/two-factor-provider-webauthn.latest-stable.zip",
+		"."
 	],
 	"mappings": {
 		"wp-content/themes/wporg-support": "WordPress/wordpress.org/wordpress.org/public_html/wp-content/themes/pub/wporg-support/",

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ WordPress.org-specific customizations for the Two Factor plugin
 
 ## Setup
 
-1. Set up a local WP site.
+1. Set up a local WP Multisite.
 1. Add this code to your `wp-config.php`:
 	```php
 	define( 'WP_ENVIRONMENT_TYPE', 'local' );
@@ -44,14 +44,14 @@ WordPress.org-specific customizations for the Two Factor plugin
 	add_action( 'init', __NAMESPACE__ . '\add_rewrite_rules' );
 	```
 1. Install, build, and activate the `wporg-support` theme.
-1. Install `bbPress` and `Gutenberg`. You might need to clone & build `trunk` branch of `Gutenberg` if we happen to be using any new features.
+1. Install `two-factor-provider-webauthn`, `bbPress` and `Gutenberg`. You might need to clone & build `trunk` branch of `Gutenberg` if we happen to be using any new features.
 1. `git clone` https://github.com/WordPress/two-factor/ into `wp-content/plugins` and follow their setup instructions.
 1. `git clone` this repo into `wp-content/plugins`
 1. `cd wporg-two-factor && composer install`
 1. `yarn && yarn workspaces run build`
 1. Setup environment tools `yarn setup:tools`
 1. Start the environment: `yarn wp-env start`
-1. Activate all four plugins.
+1. Network-activate all of the plugins.
 1. If you want to make JS changes, then `yarn workspaces run start`
 1. Open `wp-admin/options-general.php?page=bbpress` and uncheck `Prefix all forum content with the Forum Root slug (Recommended)`, then save.
 1. Visit https://example.org/users/{username}/edit/account/ to view the custom settings UI. If you get a `404` error, visit `wp-admin/options-permalinks.php` and then try again.

--- a/settings/settings.php
+++ b/settings/settings.php
@@ -25,10 +25,14 @@ function register_block() {
  * @codeCoverageIgnore
  */
 function replace_core_ui_with_custom() : void {
+	/*
+	@todo Temporarily commented so that WebAuthn can be managed via wp-admin. Restore this when our custom WebAuthn UI is ready.
+	See https://github.com/WordPress/wporg-two-factor/issues/114, https://github.com/WordPress/wporg-two-factor/issues/87.
 	remove_action( 'show_user_profile', array( 'Two_Factor_Core', 'user_two_factor_options' ) );
 	remove_action( 'edit_user_profile', array( 'Two_Factor_Core', 'user_two_factor_options' ) );
 	remove_action( 'personal_options_update', array( 'Two_Factor_Core', 'user_two_factor_options_update' ) );
 	remove_action( 'edit_user_profile_update', array( 'Two_Factor_Core', 'user_two_factor_options_update' ) );
+	*/
 
 	add_action( 'bbp_user_edit_account', __NAMESPACE__ . '\render_custom_ui' );
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -42,6 +42,7 @@ function _manually_load_plugin() {
 
 	require_once dirname( __DIR__, 3 ) . '/mu-plugins/pub/mu-plugins/loader.php';
 	require dirname( __DIR__, 2 ) . '/two-factor/two-factor.php';
+	require dirname( __DIR__, 2 ) . '/two-factor-provider-webauthn/index.php';
 	require dirname( __DIR__ ) . '/wporg-two-factor.php';
 }
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );

--- a/tests/test-wporg-two-factor.php
+++ b/tests/test-wporg-two-factor.php
@@ -48,11 +48,9 @@ class Test_WPorg_Two_Factor extends WP_UnitTestCase {
 	 */
 	public function test_two_factor_providers() : void {
 		$actual = Two_Factor_Core::get_providers();
-
 		$this->assertArrayHasKey( 'Two_Factor_Totp', $actual );
 		$this->assertArrayHasKey( 'Two_Factor_Backup_Codes', $actual );
-		// @todo enable after https://github.com/WordPress/two-factor/issues/427 merges
-		//$this->assertArrayHasKey( 'Two_Factor_WebAuthn', $actual );
+		$this->assertArrayHasKey( 'TwoFactor_Provider_WebAuthn', $actual );
 
 		$this->assertArrayNotHasKey( 'Two_Factor_Email', $actual );
 		$this->assertArrayNotHasKey( 'Two_Factor_Dummy', $actual );

--- a/wporg-two-factor.php
+++ b/wporg-two-factor.php
@@ -242,7 +242,7 @@ function get_enable_2fa_notice( string $existing_notices = '' ) : string {
  *
  * We don't want site admins making changes, etc.
  */
-function block_webauthn_settings_page( ) {
+function block_webauthn_settings_page() {
 	$screen = get_current_screen();
 
 	// Prevent direct access.

--- a/wporg-two-factor.php
+++ b/wporg-two-factor.php
@@ -42,12 +42,14 @@ add_action( 'user_has_cap', __NAMESPACE__ . '\remove_capabilities_until_2fa_enab
 function two_factor_providers( array $providers ) : array {
 	// Match the name => file path format of input var, but the path isn't needed.
 	$desired_providers = array(
-		'Two_Factor_WebAuthn'     => '',
+		'TwoFactor_Provider_WebAuthn' => '',
 		'Two_Factor_Totp'         => '',
 		'Two_Factor_Backup_Codes' => '',
 	);
 
-	return array_intersect_key( $providers, $desired_providers );
+	$providers = array_intersect_key( $providers, $desired_providers );
+
+	return $providers;
 }
 
 /**
@@ -57,8 +59,8 @@ function set_primary_provider_for_user( string $provider, int $user_id ) : strin
 	$user                = get_user_by( 'id', $user_id );
 	$available_providers = Two_Factor_Core::get_available_providers_for_user( $user );
 
-	if ( isset( $available_providers['Two_Factor_WebAuthn'] ) ) {
-		$provider = 'Two_Factor_WebAuthn';
+	if ( isset( $available_providers['TwoFactor_Provider_WebAuthn'] ) ) {
+		$provider = 'TwoFactor_Provider_WebAuthn';
 	} elseif ( isset( $available_providers['Two_Factor_Totp'] ) ) {
 		$provider = 'Two_Factor_Totp';
 	} elseif ( 'Two_Factor_Backup_Codes' === $provider && 1 === count( $available_providers ) ) {

--- a/wporg-two-factor.php
+++ b/wporg-two-factor.php
@@ -37,6 +37,7 @@ require_once __DIR__ . '/settings/settings.php';
  */
 $webauthn = WebAuthn_Plugin::instance();
 $webauthn->init();
+$webauthn->maybe_update_schema(); // This needs to run before plugins_loaded, as jetpack and wporg-two-factor do things way too early to the $current_user.
 
 add_filter( 'two_factor_providers', __NAMESPACE__ . '\two_factor_providers', 99 ); // Must run _after_ all other plugins.
 add_filter( 'two_factor_primary_provider_for_user', __NAMESPACE__ . '\set_primary_provider_for_user', 10, 2 );

--- a/wporg-two-factor.php
+++ b/wporg-two-factor.php
@@ -34,7 +34,7 @@ add_filter( 'two_factor_totp_issuer', __NAMESPACE__ . '\set_totp_issuer' );
 add_action( 'set_current_user', __NAMESPACE__ . '\remove_super_admins_until_2fa_enabled', 1 ); // Must run _before_ all other plugins.
 add_action( 'login_redirect', __NAMESPACE__ . '\redirect_to_2fa_settings', 105, 3 ); // After `wporg_remember_where_user_came_from_redirect()`, before `WP_WPorg_SSO::redirect_to_policy_update()`.
 add_action( 'user_has_cap', __NAMESPACE__ . '\remove_capabilities_until_2fa_enabled', 99, 4 ); // Must run _after_ all other plugins.
-
+add_action( 'current_screen', __NAMESPACE__ . '\block_webauthn_settings_page' );
 
 /**
  * Determine which providers should be available to users.
@@ -226,6 +226,22 @@ function get_enable_2fa_notice( string $existing_notices = '' ) : string {
 	);
 
 	return $two_factor_notice . $existing_notices;
+}
+
+/*
+ * Remove the 2FA settings page from the admin menu.
+ *
+ * We don't want site admins making changes, etc.
+ */
+function block_webauthn_settings_page( ) {
+	$screen = get_current_screen();
+
+	// Prevent direct access.
+	if ( $screen->id === 'settings_page_2fa-webauthn' ) {
+		wp_die( 'Access Denied.' );
+	}
+
+	remove_submenu_page( 'options-general.php', '2fa-webauthn' );
 }
 
 /**

--- a/wporg-two-factor.php
+++ b/wporg-two-factor.php
@@ -57,9 +57,7 @@ function two_factor_providers( array $providers ) : array {
 		'Two_Factor_Backup_Codes' => '',
 	);
 
-	$providers = array_intersect_key( $providers, $desired_providers );
-
-	return $providers;
+	return array_intersect_key( $providers, $desired_providers );
 }
 
 /**


### PR DESCRIPTION
Fixes #114
Closes #134
Closes #146
Related #142 -- This uses the same technique for bootstrapping the test suite.

This is [an alternate approach](https://github.com/WordPress/wporg-two-factor/issues/114#issuecomment-1533642960) to #134 / #146.

## To Test

1. Switch to this branch in your environment. Using a w.org sandbox is best, since local environments can't match all the complexities and quirks of production.
2. `wp plugin install two-factor-provider-webauthn`. Make sure it's at least version `2.1.0`.
3. Add this to an SVN-ignored mu-plugin to network-activate the plugin without affecting production:
	```php
	// temporary for testing #153
	add_filter( 'site_option_active_sitewide_plugins', function( $net_plugins ) {
		$net_plugins['two-factor-provider-webauthn/index.php'] = time();

		return $net_plugins;
	} );
	```

## Things to note:

* This would add `wp_2fa_webauthn_credentials` and `wp_2fa_webauthn_users` tables to the database. AFAICT the reason for that is to [avoid shared memcache servers leaking credentials](https://github.com/sjinks/wp-two-factor-provider-webauthn/blob/d82e030647da1d811a5911095314d3ee7cc000c9/inc/class-webauthn-credential-store.php#L17). If that's [rare in practice](https://security.stackexchange.com/a/139644/8467), then it doesn't seem necessary to me. It could make it harder to migrate keys when we eventually use whatever `two-factor` implements.
	* Technically, just testing it on a sandbox adds the tables to prod. If we don't go with this solution, then I'll delete them.
* Our custom UI will need to make requests to the [`webauthn_preregister`](https://github.com/sjinks/wp-two-factor-provider-webauthn/blob/d82e030647da1d811a5911095314d3ee7cc000c9/inc/class-ajax.php#L43) and [`webauthn_register`](https://github.com/sjinks/wp-two-factor-provider-webauthn/blob/d82e030647da1d811a5911095314d3ee7cc000c9/inc/class-ajax.php#L80) AJAX endpoints. Or we may want to write an additional REST API endpoint to grab some raw data like `CredentialRow->counter`, rather than parsing it out of the AJAX response.
* I tried changing the `user_verification_requirement` setting to `discouraged`, so that users won't have to enter a PIN before authenticating, but was still prompted. I think the flow would be much smoother without it, and the added security doesn't outweigh that in this scenario IMO. We're using WebAuthn as a _2nd_ factor, and Google, GitHub, and most others I've seen discourage the PIN, so it seems safe to me.
    * Hopefully this is something we'll have time to dig into after the beta launch. On the webauthn.io demo, I need to set _both_ `User Verification` and `Discoverable Credential` to `discouraged` before I can authenticate without a PIN. I don't see a way to discourage discoverable credentials here without forking.
* Currently there're [only 2 localizations](https://translate.wordpress.org/projects/wp-plugins/two-factor-provider-webauthn/). That probably isn't important for the `wp-admin` UI, since we're building a custom one anyway, but there are [two strings](https://github.com/sjinks/wp-two-factor-provider-webauthn/blob/d82e030647da1d811a5911095314d3ee7cc000c9/views/login.php#L2-L5) that show up during login. We may want to highlight this in the beta announcement to get more translations.
* https://github.com/sjinks/wp-two-factor-provider-webauthn/issues/221 might also be a blocker, but we could probably fix post-MVP
* ~~There's [a small issue PHP 8 issue](https://github.com/sjinks/wp-two-factor-provider-webauthn/issues/452), but it's shouldn't affect us yet.~~ This has been [resolved](https://github.com/sjinks/wp-two-factor-provider-webauthn/pull/455).