### PR TITLE
Disable Backup Codes UI until primary provider enabled

### DIFF
--- a/settings/.eslintrc.js
+++ b/settings/.eslintrc.js
@@ -1,4 +1,5 @@
 module.exports = {
+	root: true,
 	extends: 'plugin:@wordpress/eslint-plugin/recommended',
 
 	rules: {

--- a/settings/src/components/account-status.scss
+++ b/settings/src/components/account-status.scss
@@ -5,6 +5,12 @@
 			z-index: 1;
 		}
 
+		&.is-disabled,
+		&.is-disabled .wporg-2fa__status-card-open {
+			opacity: .6;
+			cursor: not-allowed;
+		}
+
 		a {
 			display: block;
 			text-decoration: none;

--- a/settings/src/components/backup-codes.js
+++ b/settings/src/components/backup-codes.js
@@ -19,13 +19,10 @@ export default function BackupCodes() {
 	const { userRecord } = useContext( GlobalContext );
 	const [ regenerating, setRegenerating ] = useState( false );
 
-	const backupCodesStatus = userRecord.record[ '2fa_available_providers' ].includes(
-		'Two_Factor_Backup_Codes'
-	)
-		? 'enabled'
-		: 'disabled';
+	const backupCodesEnabled =
+		userRecord.record[ '2fa_available_providers' ].includes( 'Two_Factor_Backup_Codes' );
 
-	if ( 'enabled' === backupCodesStatus && ! regenerating ) {
+	if ( backupCodesEnabled && ! regenerating ) {
 		return <Manage setRegenerating={ setRegenerating } />;
 	}
 	return <Setup setRegenerating={ setRegenerating } />;

--- a/settings/src/components/totp.js
+++ b/settings/src/components/totp.js
@@ -17,9 +17,9 @@ import { GlobalContext } from '../script';
 export default function TOTP() {
 	const { userRecord } = useContext( GlobalContext );
 	const availableProviders = userRecord.record[ '2fa_available_providers' ];
-	const totpStatus = availableProviders.includes( 'Two_Factor_Totp' ) ? 'enabled' : 'disabled';
+	const totpEnabled = availableProviders.includes( 'Two_Factor_Totp' );
 
-	if ( 'enabled' === totpStatus ) {
+	if ( totpEnabled ) {
 		return <Manage />;
 	}
 


### PR DESCRIPTION
Fixes #47

This disables the Backup Codes UI when the user hasn't enabled TOTP yet. In the future, WebAuthn can be included so that any primary provider is acceptable, rather than TOTP specifically.

Related #158  -- The UI will show Backup Codes as enabled when TOTP is disabled, but the root cause for that is outside the scope of this PR
