### PR TITLE
Require an "ordinary" provider to use Backup Codes

### DIFF
--- a/settings/settings.php
+++ b/settings/settings.php
@@ -73,6 +73,11 @@ function render_custom_ui() : void {
 	echo do_blocks( "<!-- wp:wporg-two-factor/settings $json_attrs /-->" );
 }
 
+/**
+ * Print JS and CSS for customizing the interim revalidation iframe.
+ *
+ * @codeCoverageIgnore
+ */
 function login_footer_revalidate_customizations() {
 	// When the revalidate_2fa page is displayed in an interim login on not-login, add some style and JS handlers.
 	if (

--- a/wporg-two-factor.php
+++ b/wporg-two-factor.php
@@ -37,6 +37,8 @@ require_once __DIR__ . '/settings/settings.php';
  * `Two_Factor_Core::is_user_using_two_factor()` etc assume that all providers are loaded. If WebAuthn is loaded
  * too late, then `remove_capabilities_until_2fa_enabled()` would cause `get_enable_2fa_notice()` to be shown on
  * the front end if WebAuthn is enabled and TOTP isn't.
+ *
+ * @codeCoverageIgnore
  */
 function load_webauthn_plugin() {
 	global $wpdb;
@@ -260,6 +262,8 @@ function get_enable_2fa_notice( string $existing_notices = '' ) : string {
  * Remove the 2FA settings page from the admin menu.
  *
  * We don't want site admins making changes, etc.
+ *
+ * @codeCoverageIgnore
  */
 function block_webauthn_settings_page() {
 	$screen = get_current_screen();


### PR DESCRIPTION
Fixes #158

This preserves the code from #75, but goes further to disable the provider for the user until they have an "ordinary" provider enabled.

"Ordinary" means that the provider is intended for normal use (like TOTP), as opposed to a fallback provider (like Backup Codes) that is only used when the user can't access their ordinary device.

## Testing

1. Enable TOTP and Backup Codes
2. Disable TOTP. You should see [the elevated privileges warning](https://github.com/WordPress/wporg-two-factor/blob/6a95fb3e72294a1d4a14c3a724958537dfc80259/wporg-two-factor.php#L250) on the front- and back-ends. The Backup Codes provider will also show as disabled on the front- and back-ends.

<img width="773" alt="Screenshot 2023-05-22 at 2 45 41 PM" src="https://github.com/WordPress/wporg-two-factor/assets/484068/443b57f5-90d6-4be7-8b54-7c7c346a3908">

## Notes

* If WebAuthn is enabled and TOTP is disabled, the custom UI will still show "Two-Factor auth" (TOTP) as disabled. That will be fixed by #87 and subsequent PRs.
* This doesn't automatically update the `Two_Factor_Core::ENABLED_PROVIDERS_USER_META_KEY` database value, so, there are some normal situations where the two values are out of sync.

    For example, when a new user sets up TOTP and Backup Codes through the custom UI. In that scenario, the db value will only have TOTP, but in memory it'll have Backup Codes added. If there's a subsequent save to the value, then the database will be updated to reflect the value in memory.
    
    I don't think that'll cause any tangible issues in practice, but it's worth mentioning. If we want, we could add extra code to update the DB, but the time vs benefit tradeoff doesn't seem worth it to me at this point.