### PR TITLE
WebAuthN: Disable EdDSA/Ed25519 for key registrations

### DIFF
--- a/wporg-two-factor.php
+++ b/wporg-two-factor.php
@@ -290,42 +290,6 @@ function get_edit_account_url() : string {
 	return $url;
 }
 
-/**
- * Resolve Android NFC Security Key issues when a newer key is registered through a desktop client.
- *
- * This disables EdDSA (aka. Ed25519) support, which Android NFC appears to lack.
- *
- * @see https://github.com/sjinks/wp-two-factor-provider-webauthn/issues/221
- * @codeCoverageIgnore
- */
-add_action( 'wp_ajax_webauthn_preregister', __NAMESPACE__ . '\webauthn_preregister_remove_eddsa', 1 );
-function webauthn_preregister_remove_eddsa() {
-	ob_start( __NAMESPACE__ . '\webauthn_preregister_remove_eddsa_callback' );
-}
-
-/**
- * Callback for webauthn_preregister_remove_eddsa().
- *
- * @codeCoverageIgnore
- */
-function webauthn_preregister_remove_eddsa_callback( string $output ) : string {
-	$json = json_decode( $output );
-
-	if ( $json && ! empty( $json->data->options->pubKeyCredParams ) ) {
-		$json->data->options->pubKeyCredParams = array_values(
-			wp_list_filter(
-				$json->data->options->pubKeyCredParams,
-				[ 'alg' => -8 ],
-				'NOT'
-			)
-		);
-
-		$output = wp_json_encode( $json );
-	}
-
-	return $output;
-}
-
 /*
  * Switch out the TOTP provider for one that encrypts the TOTP key.
  */


### PR DESCRIPTION
Depends on: #153 
Patch for the upstream https://github.com/sjinks/wp-two-factor-provider-webauthn/issues/221 bug
See #114 

The upstream plugin supports a multitude of algorithms, unfortunately it appears that when a modern security key is registered through a desktop browser, EdDSA is preferred, however it appears that at least some Android devices do not support this through NFC.

This PR disables the EdDSA algorithm during key registration.