### PR TITLE
Auto select TOTP input contents when focused

### DIFF
--- a/settings/src/components/auto-tabbing-input.js
+++ b/settings/src/components/auto-tabbing-input.js
@@ -9,27 +9,13 @@ import { useCallback } from '@wordpress/element';
 import NumericControl from './numeric-control';
 
 const AutoTabbingInput = ( props ) => {
-	const { inputs, setInputs, onComplete, error } = props;
+	const { inputs, setInputs, error } = props;
 
 	const handleChange = useCallback( ( value, event, index, inputRef ) => {
 		setInputs( ( prevInputs ) => {
 			const newInputs = [ ...prevInputs ];
 
-			// Clean input
-			if ( value.trim() === '' ) {
-				event.target.value = '';
-				value = '';
-			}
-
-			newInputs[ index ] = value;
-
-			// Check if all inputs are filled
-			const allFilled = newInputs.every( ( input ) => '' !== input );
-			if ( allFilled && onComplete ) {
-				onComplete( true );
-			} else {
-				onComplete( false );
-			}
+			newInputs[ index ] = value.trim() === '' ? '' : value;
 
 			return newInputs;
 		} );
@@ -51,7 +37,6 @@ const AutoTabbingInput = ( props ) => {
 		if ( inputs.length === paste.length ) {
 			event.preventDefault();
 			setInputs( paste.split( '' ) );
-			onComplete( true );
 		}
 	}, [] );
 

--- a/settings/src/components/auto-tabbing-input.js
+++ b/settings/src/components/auto-tabbing-input.js
@@ -46,17 +46,20 @@ const AutoTabbingInput = ( props ) => {
 	}, [] );
 
 	const handlePaste = useCallback( ( event ) => {
-		const paste = event.clipboardData.getData('Text').replace( /[^0-9]/g, '' )
+		const paste = event.clipboardData.getData( 'Text' ).replace( /[^0-9]/g, '' );
 
-		if ( inputs.length == paste.length ) {
+		if ( inputs.length === paste.length ) {
 			event.preventDefault();
-			setInputs( paste.split('') );
+			setInputs( paste.split( '' ) );
 			onComplete( true );
 		}
 	}, [] );
 
 	return (
-		<div className={ 'wporg-2fa__auto-tabbing-input' + ( error ? ' is-error' : '' ) } onPaste={ handlePaste }>
+		<div
+			className={ 'wporg-2fa__auto-tabbing-input' + ( error ? ' is-error' : '' ) }
+			onPaste={ handlePaste }
+		>
 			{ inputs.map( ( value, index ) => (
 				<NumericControl
 					{ ...props }

--- a/settings/src/components/auto-tabbing-input.js
+++ b/settings/src/components/auto-tabbing-input.js
@@ -9,7 +9,7 @@ import { useCallback } from '@wordpress/element';
 import NumericControl from './numeric-control';
 
 const AutoTabbingInput = ( props ) => {
-	const { inputs, setInputs, error } = props;
+	const { inputs, setInputs, error, setError } = props;
 
 	const handleChange = useCallback( ( value, event, index, inputRef ) => {
 		setInputs( ( prevInputs ) => {
@@ -32,11 +32,17 @@ const AutoTabbingInput = ( props ) => {
 	}, [] );
 
 	const handlePaste = useCallback( ( event ) => {
-		const paste = event.clipboardData.getData( 'Text' ).replace( /[^0-9]/g, '' );
+		event.preventDefault();
 
-		if ( inputs.length === paste.length ) {
-			event.preventDefault();
-			setInputs( paste.split( '' ) );
+		const newInputs = event.clipboardData
+			.getData( 'Text' )
+			.replace( /[^0-9]/g, '' )
+			.split( '' );
+
+		if ( inputs.length === newInputs.length ) {
+			setInputs( newInputs );
+		} else {
+			setError( 'The code you pasted is not the correct length.' );
 		}
 	}, [] );
 

--- a/settings/src/components/auto-tabbing-input.js
+++ b/settings/src/components/auto-tabbing-input.js
@@ -11,7 +11,7 @@ import NumericControl from './numeric-control';
 const AutoTabbingInput = ( props ) => {
 	const { inputs, setInputs, error, setError } = props;
 
-	const handleChange = useCallback( ( value, event, index, inputRef ) => {
+	const handleChange = useCallback( ( value, event, index ) => {
 		setInputs( ( prevInputs ) => {
 			const newInputs = [ ...prevInputs ];
 
@@ -19,17 +19,25 @@ const AutoTabbingInput = ( props ) => {
 
 			return newInputs;
 		} );
+	}, [] );
 
-		if ( value && '' !== value.trim() && inputRef.current.nextElementSibling ) {
-			inputRef.current.nextElementSibling.focus();
+	const handleKeyUp = useCallback( ( value, event, index, inputElement ) => {
+		// Ignore keys associated with input navigation and paste events.
+		if ( [ 'Tab', 'Shift', 'Meta' ].includes( event.key ) ) {
+			return;
+		}
+
+		if ( event.key === 'Backspace' && inputElement.previousElementSibling ) {
+			inputElement.previousElementSibling.focus();
+		} else if ( !! value && inputElement.nextElementSibling ) {
+			inputElement.nextElementSibling.focus();
 		}
 	}, [] );
 
-	const handleKeyDown = useCallback( ( value, event, index, inputRef ) => {
-		if ( event.key === 'Backspace' && ! value && inputRef.current.previousElementSibling ) {
-			inputRef.current.previousElementSibling.focus();
-		}
-	}, [] );
+	const handleFocus = useCallback(
+		( value, event, index, inputElement ) => inputElement.select(),
+		[]
+	);
 
 	const handlePaste = useCallback( ( event ) => {
 		event.preventDefault();
@@ -58,7 +66,8 @@ const AutoTabbingInput = ( props ) => {
 					key={ index }
 					index={ index }
 					onChange={ handleChange }
-					onKeyDown={ handleKeyDown }
+					onKeyUp={ handleKeyUp }
+					onFocus={ handleFocus }
 					maxLength="1"
 					required
 				/>

--- a/settings/src/components/auto-tabbing-input.js
+++ b/settings/src/components/auto-tabbing-input.js
@@ -21,16 +21,20 @@ const AutoTabbingInput = ( props ) => {
 		} );
 	}, [] );
 
-	const handleKeyUp = useCallback( ( value, event, index, inputElement ) => {
+	const handleKeyDown = useCallback( ( value, event, index, inputElement ) => {
 		// Ignore keys associated with input navigation and paste events.
-		if ( [ 'Tab', 'Shift', 'Meta' ].includes( event.key ) ) {
+		if ( [ 'Tab', 'Shift', 'Meta', 'Backspace' ].includes( event.key ) ) {
 			return;
 		}
 
+		if ( !! value && inputElement.nextElementSibling ) {
+			inputElement.nextElementSibling.focus();
+		}
+	}, [] );
+
+	const handleKeyUp = useCallback( ( value, event, index, inputElement ) => {
 		if ( event.key === 'Backspace' && inputElement.previousElementSibling ) {
 			inputElement.previousElementSibling.focus();
-		} else if ( !! value && inputElement.nextElementSibling ) {
-			inputElement.nextElementSibling.focus();
 		}
 	}, [] );
 
@@ -66,6 +70,7 @@ const AutoTabbingInput = ( props ) => {
 					key={ index }
 					index={ index }
 					onChange={ handleChange }
+					onKeyDown={ handleKeyDown }
 					onKeyUp={ handleKeyUp }
 					onFocus={ handleFocus }
 					maxLength="1"

--- a/settings/src/components/auto-tabbing-input.js
+++ b/settings/src/components/auto-tabbing-input.js
@@ -45,8 +45,18 @@ const AutoTabbingInput = ( props ) => {
 		}
 	}, [] );
 
+	const handlePaste = useCallback( ( event ) => {
+		const paste = event.clipboardData.getData('Text').replace( /[^0-9]/g, '' )
+
+		if ( inputs.length == paste.length ) {
+			event.preventDefault();
+			setInputs( paste.split('') );
+			onComplete( true );
+		}
+	}, [] );
+
 	return (
-		<div className={ 'wporg-2fa__auto-tabbing-input' + ( error ? ' is-error' : '' ) }>
+		<div className={ 'wporg-2fa__auto-tabbing-input' + ( error ? ' is-error' : '' ) } onPaste={ handlePaste }>
 			{ inputs.map( ( value, index ) => (
 				<NumericControl
 					{ ...props }

--- a/settings/src/components/numeric-control.js
+++ b/settings/src/components/numeric-control.js
@@ -13,27 +13,47 @@ import { useRef, useCallback } from '@wordpress/element';
  * using the underlying `input[type="number"]`, which has some accessibility issues.
  *
  * @param props
+ * @param props.autoComplete
+ * @param props.pattern
+ * @param props.title
+ * @param props.onChange
+ * @param props.onFocus
+ * @param props.onKeyDown
+ * @param props.onKeyUp
+ * @param props.index
+ * @param props.value
+ * @param props.maxLength
+ * @param props.required
  * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/number#accessibility
  * @see https://technology.blog.gov.uk/2020/02/24/why-the-gov-uk-design-system-team-changed-the-input-type-for-numbers/
  * @see https://stackoverflow.com/a/66759105/450127
  */
-export default function NumericControl( props ) {
-	const { autoComplete, pattern, title, onChange, onKeyDown, index, value, maxLength, required } =
-		props;
-
+export default function NumericControl( {
+	autoComplete,
+	pattern,
+	title,
+	onChange,
+	onFocus,
+	onKeyDown,
+	onKeyUp,
+	index,
+	value,
+	maxLength,
+	required,
+} ) {
 	const inputRef = useRef( null );
 
-	const handleChange = useCallback(
+	const createHandler = ( handler ) => ( event ) =>
 		// Most callers will only need the value, so make it convenient for them.
-		( event ) => onChange && onChange( event.target.value, event, index, inputRef ),
-		[]
-	);
+		handler && handler( event.target.value, event, index, inputRef.current );
 
-	const handleKeyDown = useCallback(
-		// Most callers will only need the value, so make it convenient for them.
-		( event ) => onKeyDown && onKeyDown( event.target.value, event, index, inputRef ),
-		[]
-	);
+	const handleChange = useCallback( createHandler( onChange ), [] );
+
+	const handleFocus = useCallback( createHandler( onFocus ), [] );
+
+	const handleKeyDown = useCallback( createHandler( onKeyDown ), [] );
+
+	const handleKeyUp = useCallback( createHandler( onKeyUp ), [] );
 
 	return (
 		<input
@@ -44,7 +64,9 @@ export default function NumericControl( props ) {
 			pattern={ pattern || '[0-9 ]*' }
 			title={ title || 'Only numbers and spaces are allowed' }
 			onChange={ handleChange }
+			onFocus={ handleFocus }
 			onKeyDown={ handleKeyDown }
+			onKeyUp={ handleKeyUp }
 			data-1p-ignore // Prevent 1Password from showing up
 			value={ value }
 			maxLength={ maxLength }

--- a/settings/src/components/totp.js
+++ b/settings/src/components/totp.js
@@ -4,7 +4,7 @@
 import apiFetch from '@wordpress/api-fetch';
 import { Button, Notice, Flex } from '@wordpress/components';
 import { Icon, cancelCircleFilled } from '@wordpress/icons';
-import { RawHTML, useCallback, useContext, useEffect, useState } from '@wordpress/element';
+import { RawHTML, useCallback, useContext, useEffect, useRef, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -222,11 +222,17 @@ function createQrCode( data ) {
  * @param props.setError
  */
 function SetupForm( { handleEnable, qrCodeUrl, secretKey, inputs, setInputs, error, setError } ) {
+	const inputsRef = useRef( inputs );
+
 	useEffect( () => {
-		if ( error && inputs.some( ( input ) => input === '' ) ) {
+		const prevInputs = inputsRef.current;
+		inputsRef.current = inputs;
+
+		// Clear the error if any of the inputs have changed
+		if ( error && inputs.some( ( input, index ) => input !== prevInputs[ index ] ) ) {
 			setError( '' );
 		}
-	}, [ error, inputs ] );
+	}, [ error, inputs, inputsRef ] );
 
 	const handleClearClick = useCallback( () => {
 		setInputs( Array( 6 ).fill( '' ) );

--- a/settings/src/components/totp.js
+++ b/settings/src/components/totp.js
@@ -222,21 +222,17 @@ function createQrCode( data ) {
  * @param props.setError
  */
 function SetupForm( { handleEnable, qrCodeUrl, secretKey, inputs, setInputs, error, setError } ) {
-	const [ isInputComplete, setIsInputComplete ] = useState( false );
-
 	useEffect( () => {
 		if ( error && inputs.some( ( input ) => input === '' ) ) {
 			setError( '' );
 		}
 	}, [ error, inputs ] );
 
-	const handleComplete = useCallback( ( isComplete ) => setIsInputComplete( isComplete ), [] );
 	const handleClearClick = useCallback( () => {
 		setInputs( Array( 6 ).fill( '' ) );
-		setIsInputComplete( false );
 	}, [] );
 
-	const canSubmit = qrCodeUrl && secretKey && isInputComplete;
+	const canSubmit = qrCodeUrl && secretKey && inputs.every( ( input ) => !! input );
 
 	return (
 		<Flex
@@ -254,12 +250,7 @@ function SetupForm( { handleEnable, qrCodeUrl, secretKey, inputs, setInputs, err
 			<form className="wporg-2fa__setup-form" onSubmit={ handleEnable }>
 				<p>Enter the six digit code provided by the app:</p>
 
-				<AutoTabbingInput
-					inputs={ inputs }
-					setInputs={ setInputs }
-					error={ error }
-					onComplete={ handleComplete }
-				/>
+				<AutoTabbingInput inputs={ inputs } setInputs={ setInputs } error={ error } />
 
 				<div className="wporg-2fa__submit-btn-container">
 					<Button

--- a/settings/src/components/totp.js
+++ b/settings/src/components/totp.js
@@ -250,7 +250,12 @@ function SetupForm( { handleEnable, qrCodeUrl, secretKey, inputs, setInputs, err
 			<form className="wporg-2fa__setup-form" onSubmit={ handleEnable }>
 				<p>Enter the six digit code provided by the app:</p>
 
-				<AutoTabbingInput inputs={ inputs } setInputs={ setInputs } error={ error } />
+				<AutoTabbingInput
+					inputs={ inputs }
+					setInputs={ setInputs }
+					error={ error }
+					setError={ setError }
+				/>
 
 				<div className="wporg-2fa__submit-btn-container">
 					<Button

--- a/settings/src/components/totp.js
+++ b/settings/src/components/totp.js
@@ -231,7 +231,10 @@ function SetupForm( { handleEnable, qrCodeUrl, secretKey, inputs, setInputs, err
 	}, [ error, inputs ] );
 
 	const handleComplete = useCallback( ( isComplete ) => setIsInputComplete( isComplete ), [] );
-	const handleClearClick = useCallback( () => setInputs( Array( 6 ).fill( '' ) ), [] );
+	const handleClearClick = useCallback( () => {
+		setInputs( Array( 6 ).fill( '' ) );
+		setIsInputComplete( false );
+	}, [] );
 
 	const canSubmit = qrCodeUrl && secretKey && isInputComplete;
 


### PR DESCRIPTION
Closes #155 

This PR builds upon the paste handler added in #154

When an input is focused its contents are automatically selected, allowing the user to use Tab to move back and forth and type over previous values.

![totp auto select](https://github.com/WordPress/wporg-two-factor/assets/1017872/94a3e70d-76bf-4be1-95f6-a676945a0a73)

### How to test

Combinations of typing values, tabbing forwards and backwards, pasting, delete with backspace, clear all.

