### PR TITLE
Remove the Two_Factor profile actions from non-admin contexts only.

### DIFF
--- a/settings/settings.php
+++ b/settings/settings.php
@@ -26,13 +26,15 @@ function register_block() {
  */
 function replace_core_ui_with_custom() : void {
 	/*
-	@todo Temporarily commented so that WebAuthn can be managed via wp-admin. Restore this when our custom WebAuthn UI is ready.
-	See https://github.com/WordPress/wporg-two-factor/issues/114, https://github.com/WordPress/wporg-two-factor/issues/87.
-	remove_action( 'show_user_profile', array( 'Two_Factor_Core', 'user_two_factor_options' ) );
-	remove_action( 'edit_user_profile', array( 'Two_Factor_Core', 'user_two_factor_options' ) );
-	remove_action( 'personal_options_update', array( 'Two_Factor_Core', 'user_two_factor_options_update' ) );
-	remove_action( 'edit_user_profile_update', array( 'Two_Factor_Core', 'user_two_factor_options_update' ) );
-	*/
+	 * @todo Temporarily commented so that WebAuthn can be managed via wp-admin. Restore this when our custom WebAuthn UI is ready.
+	 * See https://github.com/WordPress/wporg-two-factor/issues/114, https://github.com/WordPress/wporg-two-factor/issues/87.
+	 */
+	if ( ! is_admin() ) {
+		remove_action( 'show_user_profile', array( 'Two_Factor_Core', 'user_two_factor_options' ) );
+		remove_action( 'edit_user_profile', array( 'Two_Factor_Core', 'user_two_factor_options' ) );
+		remove_action( 'personal_options_update', array( 'Two_Factor_Core', 'user_two_factor_options_update' ) );
+		remove_action( 'edit_user_profile_update', array( 'Two_Factor_Core', 'user_two_factor_options_update' ) );
+	}
 
 	add_action( 'bbp_user_edit_account', __NAMESPACE__ . '\render_custom_ui' );
 


### PR DESCRIPTION
After #153 we've got the Two Factor UI showing [up on the bbPress edit user screen](https://wordpress.org/support/users/profile/edit/), but the WebAuthn plugin doesn't support being displayed there so it doesn't show up.

This PR hides the Two Factor UI on the front-end again, and retains it for wp-admin contexts.