### PR TITLE
Fix dirty password prevent email from saving

### DIFF
--- a/settings/src/components/tests/utlitites.test.js
+++ b/settings/src/components/tests/utlitites.test.js
@@ -38,14 +38,6 @@ describe( 'useUser', () => {
 		expect( user.isSaving ).toBeTruthy();
 	} );
 
-	it( 'should initialize password in user.userRecord.record if not defined', () => {
-		useEntityRecord.mockReturnValue( { record: {} } );
-
-		const user = useUser( 1 );
-
-		expect( user.userRecord.record.password ).toBe( '' );
-	} );
-
 	it( 'should not overwrite password in user.userRecord.record if already defined', () => {
 		useEntityRecord.mockReturnValue( {
 			record: { password: 'test-password' },

--- a/settings/src/script.js
+++ b/settings/src/script.js
@@ -115,14 +115,14 @@ function Main( { userId } ) {
 			event.preventDefault();
 
 			// Reset to initial after navigating away from a page.
+			// Note: password was initially not in record, this would prevent incomplete state
+			// from resetting when leaving the password setting page.
+			// See https://github.com/WordPress/wporg-two-factor/issues/117#issuecomment-1515693367.
 			if ( hasEdits ) {
-				edit( record );
-
-				// password is not reset by edit(record) as it's initially set as undefined.
-				// See https://github.com/WordPress/wporg-two-factor/issues/117#issuecomment-1515693367.
-				// we've tried setting its initial value as empty string, but this prevented email from being updated.
-				// See https://github.com/WordPress/wporg-two-factor/issues/175.
-				record.password = undefined;
+				edit( {
+					...record,
+					password: undefined,
+				} );
 			}
 
 			currentUrl = new URL( document.location.href );

--- a/settings/src/script.js
+++ b/settings/src/script.js
@@ -117,6 +117,12 @@ function Main( { userId } ) {
 			// Reset to initial after navigating away from a page.
 			if ( hasEdits ) {
 				edit( record );
+
+				// password is not reset by edit(record) as it's initially set as undefined.
+				// See https://github.com/WordPress/wporg-two-factor/issues/117#issuecomment-1515693367.
+				// we've tried setting its initial value as empty string, but this prevented email from being updated.
+				// See https://github.com/WordPress/wporg-two-factor/issues/175.
+				record.password = undefined;
 			}
 
 			currentUrl = new URL( document.location.href );

--- a/settings/src/utilities.js
+++ b/settings/src/utilities.js
@@ -24,12 +24,6 @@ export function useUser( userId ) {
 		hasPrimaryProvider,
 	};
 
-	// Initialize the password as an empty string, necessary for resetting incomplete state when
-	// leaving the password setting page.
-	if ( user.userRecord.record && undefined === user.userRecord.record?.password ) {
-		user.userRecord.record.password = '';
-	}
-
 	return user;
 }
 

--- a/settings/src/utilities.js
+++ b/settings/src/utilities.js
@@ -18,13 +18,11 @@ export function useUser( userId ) {
 		primaryProviders.includes( provider )
 	).length;
 
-	const user = {
+	return {
 		userRecord: { ...userRecord },
 		isSaving,
 		hasPrimaryProvider,
 	};
-
-	return user;
 }
 
 /**


### PR DESCRIPTION
Fixes #175

This PR fixes the issue that a dirty password prevents email from saving. A reassigning statement was added to the `script.js` to explicitly reset the password to its initial value.

## Screencast

https://github.com/WordPress/wporg-two-factor/assets/18050944/13e2d60d-f023-4959-97f1-f6d26d23b197


