### PR TITLE
Remove fixed height so QR code can grow based on username length

### DIFF
--- a/settings/src/components/totp.scss
+++ b/settings/src/components/totp.scss
@@ -68,7 +68,6 @@
 
 	.wporg-2fa__qr-code {
 		text-align: center;
-		height: 225px;
 
 		#bbpress-forums & {
 			> a {


### PR DESCRIPTION
Fixes #163 

Otherwise a longer username would overflow the container and overlap surrounding elements.

See https://github.com/WordPress/two-factor/blob/654ebb75024c21c116b4155e7254e143c9f64413/providers/class-two-factor-totp.php#L234

