### PR TITLE
Set default colors to legacy WP

### DIFF
--- a/settings/src/style.scss
+++ b/settings/src/style.scss
@@ -1,3 +1,5 @@
+@import '~@wordpress/base-styles/mixins';
+@import '~@wordpress/base-styles/default-custom-properties';
 @import '~@wordpress/base-styles/colors';
 @import '~@wordpress/base-styles/colors.native';
 


### PR DESCRIPTION
Fixes #167 

This PR implements [the documented way of resetting the admin theme colors](https://github.com/WordPress/gutenberg/pull/50193) to be based on the legacy `#007cba` rather than Blueberry.

Currently it isn't working however, even though [`block.json` has `wp-components` as a dependency](--wp-admin-theme-color), the components styles are loaded last, overriding `--wp-admin-theme-color`.