### PR TITLE
Add workaround for reauth modal immediately closing in Firefox

### DIFF
--- a/settings/src/components/revalidate-modal.js
+++ b/settings/src/components/revalidate-modal.js
@@ -17,6 +17,9 @@ export default function RevalidateModal() {
 			title="Two-Factor Authentication"
 			onRequestClose={ goBack }
 			className="wporg-2fa__revalidate-modal"
+			// Temporary workaround until https://github.com/WordPress/gutenberg/issues/40912 is fixed.
+			// Without this the modal immediately closes in Firefox, see https://github.com/WordPress/wporg-two-factor/issues/180
+			shouldCloseOnClickOutside={ false }
 		>
 			<p>To update your two-factor options, you must first revalidate your session.</p>
 


### PR DESCRIPTION
Fixes #180 

This PR introduces the workaround mentioned on https://github.com/WordPress/gutenberg/issues/40912, which is to add `shouldCloseOnClickOutside={ false }` to the modal component, stopping the focus event in the iframe from closing the modal.

The downside is that clicking the modal background will not close the modal anymore, but the close button still works.


### Testing

**Ensure you use Firefox and other browsers.**

To force the modal to popup on the TOTP screen you can modify the [script.js condition](https://github.com/WordPress/wporg-two-factor/blob/trunk/settings/src/script.js#L166) to something like

```
else if ( twoFactorRequiredScreens.includes( screen ) ) {
    ...
```