### PR TITLE
Extend the revalidation time after TOTP/WebAuthn are setup, properly set/remove 2fa session flag

### DIFF
--- a/class-encrypted-totp-provider.php
+++ b/class-encrypted-totp-provider.php
@@ -1,6 +1,7 @@
 <?php
 namespace WordPressdotorg\Two_Factor;
 use Two_Factor_Totp;
+use function WordPressdotorg\Two_Factor\{ after_provider_setup, after_provider_deactivated };
 
 /**
  * Extends the default Two_Factor_Totp class to encrypt the TOTP key.
@@ -25,7 +26,30 @@ class Encrypted_Totp_Provider extends Two_Factor_Totp {
 			$key = wporg_encrypt( $key, (string) $user_id, 'two-factor' );
 		}
 
-		return parent::set_user_totp_key( $user_id, (string) $key );
+		$result = parent::set_user_totp_key( $user_id, (string) $key );
+
+		if ( $result ) {
+			after_provider_setup( $user_id, $this );
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Delete the TOTP secret key for a user.
+	 *
+	 * @param  int $user_id User ID.
+	 *
+	 * @return boolean If the key was deleted successfully.
+	 */
+	public function delete_user_totp_key( $user_id ) {
+		$result = parent::delete_user_totp_key( $user_id );
+
+		if ( $result ) {
+			after_provider_deactivated( $user_id, $this );
+		}
+
+		return $result;
 	}
 
 	/**

--- a/class-wporg-webauthn-provider.php
+++ b/class-wporg-webauthn-provider.php
@@ -7,6 +7,8 @@ use function WordPressdotorg\Two_Factor\{ after_provider_setup, after_provider_d
  * Extends the TwoFactor_Provider_WebAuthn class for WordPress.org needs.
  */
 class WPORG_TwoFactor_Provider_WebAuthn extends TwoFactor_Provider_WebAuthn {
+	static $use_caching = true;
+
 	/**
 	 * Use the parent class as the "key" in the Two Factor UI.
 	 */
@@ -43,7 +45,7 @@ class WPORG_TwoFactor_Provider_WebAuthn extends TwoFactor_Provider_WebAuthn {
 	 */
 	public function is_available_for_user( $user ) {
 		$is_available = wp_cache_get( 'webauthn:' . $user->ID, 'users', false, $found );
-		if ( $found ) {
+		if ( $found && self::$use_caching ) {
 			return $is_available;
 		}
 
@@ -92,6 +94,9 @@ class WPORG_TwoFactor_Provider_WebAuthn extends TwoFactor_Provider_WebAuthn {
 	 * This is pending an upstream PR for the revalidation.
 	 */
 	public function _webauthn_ajax_request() {
+		// Disable caching while we're making WebAuthn requests.
+		self::$use_caching = false;
+
 		// Check the users session is still active and 2FA revalidation isn't required.
 		if ( ! Two_Factor_Core::current_user_can_update_two_factor_options() ) {
 			wp_send_json_error( 'Your session has expired. Please refresh the page and try again.' );

--- a/wporg-two-factor.php
+++ b/wporg-two-factor.php
@@ -307,15 +307,12 @@ function get_edit_account_url() : string {
 function after_provider_setup( $user_id, $provider ) {
 	$user_id = intval( $user_id );
 
-	error_log( __FUNCTION__ . " called for user {$user_id} with provider {" . get_class( $provider ) . "}" );
-
 	if ( $user_id !== get_current_user_id() ) {
 		return;
 	}
 
 	// Bump session revalidation upon TOTP being setup.
 	if ( Two_Factor_Core::is_current_user_session_two_factor() ) {
-		// Bump time
 		Two_Factor_Core::update_current_user_session( [
 			'two-factor-login' => time(),
 		] );
@@ -336,7 +333,6 @@ function after_provider_setup( $user_id, $provider ) {
  */
 function after_provider_deactivated( $user_id, $provider = null ) {
 	$user_id = intval( $user_id );
-	error_log( __FUNCTION__ . " called for user {$user_id} with provider {" . get_class( $provider ) . "}" );
 
 	if ( $user_id !== get_current_user_id() ) {
 		return;
@@ -350,8 +346,6 @@ function after_provider_deactivated( $user_id, $provider = null ) {
 
 	// Workaround until #164 lands.
 	unset( $available_providers['Two_Factor_Backup_Codes'] );
-
-	error_log( print_r( $available_providers, true ) );
 
 	// If they no longer have 2FA providers setup, remove the session meta.
 	if ( ! $available_providers ) {

--- a/wporg-two-factor.php
+++ b/wporg-two-factor.php
@@ -311,18 +311,11 @@ function after_provider_setup( $user_id, $provider ) {
 		return;
 	}
 
-	// Bump session revalidation upon TOTP being setup.
-	if ( Two_Factor_Core::is_current_user_session_two_factor() ) {
-		Two_Factor_Core::update_current_user_session( [
-			'two-factor-login' => time(),
-		] );
-	} else {
-		// Set the session to be two-factor.
-		Two_Factor_Core::update_current_user_session( [
-			'two-factor-provider' => $provider->get_key(),
-			'two-factor-login'    => time(),
-		] );
-	}
+	// Bump session revalidation upon it being setup, or a new key configured.
+	Two_Factor_Core::update_current_user_session( [
+		'two-factor-provider' => $provider->get_key(),
+		'two-factor-login'    => time(),
+	] );
 }
 
 /**


### PR DESCRIPTION
Fixes #173 
Fixes #179 

A downside of the upstream implementation _(authored by, me...)_ of revalidation is that it's based on when a provider is **enabled**, not _setup_.
The upstream Two-Factor UI has knowledge of when the provider is enabled, but it has no idea of the configuration state of the providers, or when the providers configuration is setup/cleared. The only way it can find this out is by querying the providers, but the providers don't let it know when they've had a configuration change.

All that, combined with us not actually calling the upstream UI save handler.. results in us having to call it ourselves.

This PR extends our custom TOTP/WebAuthn classes to call wporg-two-factor functions to let it know it's been configured/deconfigured, such that we can take action like bumping the revalidation time to `time()` or flagging the session as no longer 2fa if they've removed all providers.
