### PR TITLE
Add try...catch to handle backup API failure

### DIFF
--- a/settings/src/components/backup-codes.js
+++ b/settings/src/components/backup-codes.js
@@ -9,6 +9,7 @@ import { Icon, warning, cancelCircleFilled } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
+import RevalidateModal from './revalidate-modal';
 import { GlobalContext } from '../script';
 import { refreshRecord } from '../utilities';
 
@@ -91,10 +92,13 @@ function Setup( { setRegenerating } ) {
 			<p>Please print the codes and keep them in a safe place.</p>
 
 			{ error ? (
-				<Notice status="error" isDismissible={ false }>
-					<Icon icon={ cancelCircleFilled } />
-					{ error.message }
-				</Notice>
+				<>
+					{ error.code === 'revalidation_required' && <RevalidateModal /> }
+					<Notice status="error" isDismissible={ false }>
+						<Icon icon={ cancelCircleFilled } />
+						{ error.message }
+					</Notice>
+				</>
 			) : (
 				<>
 					<CodeList codes={ backupCodes } />

--- a/settings/src/components/backup-codes.js
+++ b/settings/src/components/backup-codes.js
@@ -9,7 +9,6 @@ import { Icon, warning, cancelCircleFilled } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import RevalidateModal from './revalidate-modal';
 import { GlobalContext } from '../script';
 import { refreshRecord } from '../utilities';
 
@@ -92,13 +91,10 @@ function Setup( { setRegenerating } ) {
 			<p>Please print the codes and keep them in a safe place.</p>
 
 			{ error ? (
-				<>
-					{ error.code === 'revalidation_required' && <RevalidateModal /> }
-					<Notice status="error" isDismissible={ false }>
-						<Icon icon={ cancelCircleFilled } />
-						{ error.message }
-					</Notice>
-				</>
+				<Notice status="error" isDismissible={ false }>
+					<Icon icon={ cancelCircleFilled } />
+					{ error.message }
+				</Notice>
 			) : (
 				<>
 					<CodeList codes={ backupCodes } />


### PR DESCRIPTION
Fixes #182 

This PR adds try...catch to handle backup API failure, rendering an error notice when the API doesn't work correctly.

## Testing Steps

Go to `account-status.js` and comment out `disabled={ ! backupCodesEnabled }` on L78.

Scenario 1 - `error.code === 'revalidation_required'`

1. Go to `wp-content/plugins/two-factor/class-two-factor-core.php` and remove the `!` for the if condition on L1209.
=> `if ( self::current_user_can_update_two_factor_options( 'save' ) ) {`
2. Go to `/?screen=backup-codes` and it's expected to have the same results as the screenshot below.

Local

![revalidation_require](https://github.com/WordPress/wporg-two-factor/assets/18050944/79b99871-7d2f-4941-81da-6cc852ddbfff)

Sandbox

![sandbox](https://github.com/WordPress/wporg-two-factor/assets/18050944/99fb4687-b399-40c8-aeb9-f193082624e1)

Scenario 2 - other kinds of error
1. Go to `wp-content/plugins/two-factor/providers/class-two-factor-backup-codes.php` and make it always throw an error on L295.
2. Go to `/?screen=backup-codes` and it's expected to have the same results as the screenshot below - an error notice with an error message is shown.

![other errors](https://github.com/WordPress/wporg-two-factor/assets/18050944/a6c7da27-a69b-452b-8fbc-c901509070c3)

## Question
Do we want to show error messages dynamically on the front-end side, or alternatively, a certain error message like "Something went wrong, please seek assistance somewhere" could probably be displayed? As the error message like `"Unable to enable recovery codes for this user."` needs rephrasing a bit.