### PR TITLE
Handle revalidation error in a single place

### DIFF
--- a/settings/src/components/backup-codes.js
+++ b/settings/src/components/backup-codes.js
@@ -46,10 +46,11 @@ function Setup( { setRegenerating } ) {
 	const {
 		setGlobalNotice,
 		user: { userRecord },
+		setError,
+		error,
 	} = useContext( GlobalContext );
 	const [ backupCodes, setBackupCodes ] = useState( [] );
 	const [ hasPrinted, setHasPrinted ] = useState( false );
-	const [ error, setError ] = useState( '' );
 
 	// Generate new backup codes and save them in usermeta.
 	useEffect( () => {

--- a/settings/src/script.js
+++ b/settings/src/script.js
@@ -72,7 +72,7 @@ function Main( { userId } ) {
 		email: <EmailAddress />,
 		password: <Password />,
 		totp: <TOTP />,
-		'backup-codes': <BackupCodes setScreen={ setScreen } />,
+		'backup-codes': <BackupCodes />,
 	};
 
 	// TODO: Only enable WebAuthn UI in development, until it's finished.

--- a/settings/src/script.js
+++ b/settings/src/script.js
@@ -132,6 +132,7 @@ function Main( { userId } ) {
 			currentUrl.searchParams.set( 'screen', nextScreen );
 			window.history.pushState( {}, '', currentUrl );
 
+			setError( '' );
 			setGlobalNotice( '' );
 			setScreen( nextScreen );
 		},

--- a/settings/src/script.js
+++ b/settings/src/script.js
@@ -170,18 +170,14 @@ function Main( { userId } ) {
 				<CardBody className={ 'wporg-2fa__' + screen }>{ currentScreen }</CardBody>
 			</Card>
 		);
-	} else if (
+	}
+
+	const isRevalidationExpired =
 		twoFactorRequiredScreens.includes( screen ) &&
 		hasPrimaryProvider &&
-		record[ '2fa_revalidation' ]?.expires_at <= new Date().getTime() / 1000
-	) {
-		screenContent = (
-			<>
-				{ currentScreen }
-				<RevalidateModal />
-			</>
-		);
-	}
+		record[ '2fa_revalidation' ]?.expires_at <= new Date().getTime() / 1000;
+
+	const shouldRevalidate = 'revalidation_required' === error.code || isRevalidationExpired;
 
 	return (
 		<GlobalContext.Provider
@@ -189,7 +185,7 @@ function Main( { userId } ) {
 		>
 			<GlobalNotice notice={ globalNotice } setNotice={ setGlobalNotice } />
 			{ screenContent }
-			{ 'revalidation_required' === error.code && <RevalidateModal /> }
+			{ shouldRevalidate && <RevalidateModal /> }
 		</GlobalContext.Provider>
 	);
 }

--- a/settings/src/script.js
+++ b/settings/src/script.js
@@ -61,6 +61,7 @@ function Main( { userId } ) {
 		hasPrimaryProvider,
 	} = user;
 	const [ globalNotice, setGlobalNotice ] = useState( '' );
+	const [ error, setError ] = useState( '' );
 
 	let currentUrl = new URL( document.location.href );
 	let initialScreen = currentUrl.searchParams.get( 'screen' );
@@ -183,9 +184,12 @@ function Main( { userId } ) {
 	}
 
 	return (
-		<GlobalContext.Provider value={ { navigateToScreen, user, setGlobalNotice } }>
+		<GlobalContext.Provider
+			value={ { navigateToScreen, user, setGlobalNotice, setError, error } }
+		>
 			<GlobalNotice notice={ globalNotice } setNotice={ setGlobalNotice } />
 			{ screenContent }
+			{ 'revalidation_required' === error.code && <RevalidateModal /> }
 		</GlobalContext.Provider>
 	);
 }

--- a/settings/src/script.js
+++ b/settings/src/script.js
@@ -72,7 +72,7 @@ function Main( { userId } ) {
 		email: <EmailAddress />,
 		password: <Password />,
 		totp: <TOTP />,
-		'backup-codes': <BackupCodes />,
+		'backup-codes': <BackupCodes setScreen={ setScreen } />,
 	};
 
 	// TODO: Only enable WebAuthn UI in development, until it's finished.


### PR DESCRIPTION
Fixes https://github.com/WordPress/wporg-two-factor/pull/187#discussion_r1206073166

## Testing Step

1. Go to `account-status.js` and comment out `disabled={ ! backupCodesEnabled }` on L78.
2. Go to `wp-content/plugins/two-factor/class-two-factor-core.php` and remove the `!` for the if condition on L1209.
=> `if ( self::current_user_can_update_two_factor_options( 'save' ) ) {`
3. Comment out the following snippet in `/wp-content/plugins/wporg-two-factor/settings/src/components/backup-codes.js` 
```
if ( ! totpEnabled ) {
	const currentUrl = new URL( document.location.href );
	currentUrl.searchParams.set( 'screen', 'account-status' );
	window.history.pushState( {}, '', currentUrl );
	setScreen( 'account-status' );
	return;
}
```
4. You will see the Modal popup when visiting `/?screen=backup-codes`. If you want to observe the same behavior as in the clip below, please use sandbox and make sure you have had 2fa set up, and then do `2.` above.

https://github.com/WordPress/wporg-two-factor/assets/18050944/9d12e948-c7bd-4f8e-a300-d8f6019cf610

## TODO

If this method works, pulling up all the `setError` and `error` in child components to `script.js`
