### PR TITLE
Fix backup codes screen status not updated if go back without checkbox confirmed

### DIFF
--- a/settings/src/components/account-status.js
+++ b/settings/src/components/account-status.js
@@ -121,7 +121,11 @@ function SettingStatusCard( { screen, status, headerText, bodyText, disabled = f
 
 	return (
 		<Card className={ classes }>
-			{ disabled ? cardContent : <ScreenLink screen={ screen } anchorText={ cardContent } /> }
+			{ disabled ? (
+				cardContent
+			) : (
+				<ScreenLink nextScreen={ screen } anchorText={ cardContent } />
+			) }
 		</Card>
 	);
 }

--- a/settings/src/components/backup-codes.js
+++ b/settings/src/components/backup-codes.js
@@ -87,7 +87,18 @@ function Setup( { setRegenerating } ) {
 		await refreshRecord( userRecord ); // This has the intended side-effect of redirecting to the Manage screen.
 		setGlobalNotice( 'Backup codes have been enabled.' );
 		setRegenerating( false );
-	} );
+	}, [] );
+
+	const handleCheckboxChange = useCallback(
+		( checked ) => {
+			setHasBackupCodesPrinted( checked );
+			// Error should disappear when the user interacts with the checkbox again.
+			if ( 'checkbox_confirmation_required' === error.code ) {
+				setError( '' );
+			}
+		},
+		[ error.code ]
+	);
 
 	return (
 		<>
@@ -99,30 +110,28 @@ function Setup( { setRegenerating } ) {
 
 			<p>Please print the codes and keep them in a safe place.</p>
 
-			{ error ? (
+			<CodeList codes={ backupCodes } />
+
+			<Notice status="warning" isDismissible={ false }>
+				<Icon icon={ warning } className="wporg-2fa__print-codes-warning" />
+				Without access to the one-time password app or a backup code, you will lose access
+				to your account. Once you navigate away from this page, you will not be able to view
+				these codes again.
+			</Notice>
+
+			{ error && (
 				<Notice status="error" isDismissible={ false }>
 					<Icon icon={ cancelCircleFilled } />
 					{ error.message }
 				</Notice>
-			) : (
-				<>
-					<CodeList codes={ backupCodes } />
-
-					<Notice status="warning" isDismissible={ false }>
-						<Icon icon={ warning } className="wporg-2fa__print-codes-warning" />
-						Without access to the one-time password app or a backup code, you will lose
-						access to your account. Once you navigate away from this page, you will not
-						be able to view these codes again.
-					</Notice>
-
-					<CheckboxControl
-						label="I have printed or saved these codes"
-						checked={ hasBackupCodesPrinted }
-						onChange={ setHasBackupCodesPrinted }
-						disabled={ error }
-					/>
-				</>
 			) }
+
+			<CheckboxControl
+				label="I have printed or saved these codes"
+				checked={ hasBackupCodesPrinted }
+				onChange={ handleCheckboxChange }
+				disabled={ error && 'checkbox_confirmation_required' !== error.code }
+			/>
 
 			<p className="wporg-2fa__submit-actions">
 				<Button isPrimary disabled={ ! hasBackupCodesPrinted } onClick={ handleFinished }>

--- a/settings/src/components/backup-codes.js
+++ b/settings/src/components/backup-codes.js
@@ -25,7 +25,7 @@ export default function BackupCodes() {
 	// If TOTP hasn't been enabled, the user should not have access to BackupCodes component.
 	// This is primarily added to prevent users from accessing through the URL.
 	if ( ! totpEnabled ) {
-		navigateToScreen( 'account-status' );
+		navigateToScreen( { nextScreen: 'account-status' } );
 		return;
 	}
 

--- a/settings/src/components/backup-codes.js
+++ b/settings/src/components/backup-codes.js
@@ -84,9 +84,10 @@ function Setup( { setRegenerating } ) {
 	}, [] );
 
 	// Finish the setup process.
-	const handleFinished = useCallback( () => {
+	const handleFinished = useCallback( async () => {
+		// TODO: Add try catch here after https://github.com/WordPress/wporg-two-factor/pull/187/files is merged.
 		// The codes have already been saved to usermeta, see `generateCodes()` above.
-		refreshRecord( userRecord ); // This has the intended side-effect of redirecting to the Manage screen.
+		await refreshRecord( userRecord ); // This has the intended side-effect of redirecting to the Manage screen.
 		setGlobalNotice( 'Backup codes have been enabled.' );
 		setRegenerating( false );
 	} );

--- a/settings/src/components/backup-codes.js
+++ b/settings/src/components/backup-codes.js
@@ -46,10 +46,11 @@ function Setup( { setRegenerating } ) {
 	const {
 		setGlobalNotice,
 		user: { userRecord },
+		setError,
+		error,
 	} = useContext( GlobalContext );
 	const [ backupCodes, setBackupCodes ] = useState( [] );
 	const [ hasPrinted, setHasPrinted ] = useState( false );
-	const [ error, setError ] = useState( '' );
 
 	// Generate new backup codes and save them in usermeta.
 	useEffect( () => {

--- a/settings/src/components/backup-codes.js
+++ b/settings/src/components/backup-codes.js
@@ -14,23 +14,18 @@ import { refreshRecord } from '../utilities';
 
 /**
  * Setup and manage backup codes.
- *
- * @param props
- * @param props.setScreen
  */
-export default function BackupCodes( { setScreen } ) {
+export default function BackupCodes() {
 	const {
-		user: { totpEnabled, backupCodesEnabled },
+		user: { backupCodesEnabled, totpEnabled },
+		navigateToScreen,
 	} = useContext( GlobalContext );
 	const [ regenerating, setRegenerating ] = useState( false );
 
 	// If TOTP hasn't been enabled, the user should not have access to BackupCodes component.
 	// This is primarily added to prevent users from accessing through the URL.
 	if ( ! totpEnabled ) {
-		const currentUrl = new URL( document.location.href );
-		currentUrl.searchParams.set( 'screen', 'account-status' );
-		window.history.pushState( {}, '', currentUrl );
-		setScreen( 'account-status' );
+		navigateToScreen( 'account-status' );
 		return;
 	}
 

--- a/settings/src/components/backup-codes.js
+++ b/settings/src/components/backup-codes.js
@@ -48,9 +48,10 @@ function Setup( { setRegenerating } ) {
 		user: { userRecord },
 		setError,
 		error,
+		hasBackupCodesPrinted,
+		setHasBackupCodesPrinted,
 	} = useContext( GlobalContext );
 	const [ backupCodes, setBackupCodes ] = useState( [] );
-	const [ hasPrinted, setHasPrinted ] = useState( false );
 
 	// Generate new backup codes and save them in usermeta.
 	useEffect( () => {
@@ -116,15 +117,15 @@ function Setup( { setRegenerating } ) {
 
 					<CheckboxControl
 						label="I have printed or saved these codes"
-						checked={ hasPrinted }
-						onChange={ setHasPrinted }
+						checked={ hasBackupCodesPrinted }
+						onChange={ setHasBackupCodesPrinted }
 						disabled={ error }
 					/>
 				</>
 			) }
 
 			<p className="wporg-2fa__submit-actions">
-				<Button isPrimary disabled={ ! hasPrinted } onClick={ handleFinished }>
+				<Button isPrimary disabled={ ! hasBackupCodesPrinted } onClick={ handleFinished }>
 					All Finished
 				</Button>
 			</p>

--- a/settings/src/components/backup-codes.js
+++ b/settings/src/components/backup-codes.js
@@ -186,6 +186,11 @@ function Manage( { setRegenerating } ) {
 			setHasBackupCodesPrinted,
 		},
 	} = useContext( GlobalContext );
+
+	// In Manage screen, always initialize "hasBackupCodesPrinted" as true.
+	// Otherwise, if users leave the account screen and return, it would default back to false, and the 'Back' button would be unclickable.
+	useEffect( () => setHasBackupCodesPrinted( true ), [] );
+
 	const remaining = record[ '2fa_backup_codes_remaining' ];
 
 	return (

--- a/settings/src/components/backup-codes.js
+++ b/settings/src/components/backup-codes.js
@@ -183,6 +183,7 @@ function Manage( { setRegenerating } ) {
 	const {
 		user: {
 			userRecord: { record },
+			setHasBackupCodesPrinted,
 		},
 	} = useContext( GlobalContext );
 	const remaining = record[ '2fa_backup_codes_remaining' ];
@@ -214,6 +215,7 @@ function Manage( { setRegenerating } ) {
 				isSecondary
 				onClick={ () => {
 					setRegenerating( true );
+					setHasBackupCodesPrinted( false );
 				} }
 			>
 				Generate new backup codes

--- a/settings/src/components/backup-codes.js
+++ b/settings/src/components/backup-codes.js
@@ -14,12 +14,25 @@ import { refreshRecord } from '../utilities';
 
 /**
  * Setup and manage backup codes.
+ *
+ * @param props
+ * @param props.setScreen
  */
-export default function BackupCodes() {
+export default function BackupCodes( { setScreen } ) {
 	const {
-		user: { backupCodesEnabled },
+		user: { totpEnabled, backupCodesEnabled },
 	} = useContext( GlobalContext );
 	const [ regenerating, setRegenerating ] = useState( false );
+
+	// If TOTP hasn't been enabled, the user should not have access to BackupCodes component.
+	// This is primarily added to prevent users from accessing through the URL.
+	if ( ! totpEnabled ) {
+		const currentUrl = new URL( document.location.href );
+		currentUrl.searchParams.set( 'screen', 'account-status' );
+		window.history.pushState( {}, '', currentUrl );
+		setScreen( 'account-status' );
+		return;
+	}
 
 	if ( backupCodesEnabled && ! regenerating ) {
 		return <Manage setRegenerating={ setRegenerating } />;

--- a/settings/src/components/revalidate-modal.js
+++ b/settings/src/components/revalidate-modal.js
@@ -12,7 +12,7 @@ export default function RevalidateModal() {
 
 	const goBack = useCallback( ( event ) => {
 		event.preventDefault();
-		navigateToScreen( 'account-status' );
+		navigateToScreen( { nextScreen: 'account-status' } );
 	}, [] );
 
 	return (

--- a/settings/src/components/revalidate-modal.js
+++ b/settings/src/components/revalidate-modal.js
@@ -53,6 +53,7 @@ function RevalidateIframe() {
 				await refreshRecord( userRecord );
 			} catch ( error ) {
 				// TODO: handle error more properly here, likely by showing a error notice
+				// eslint-disable-next-line no-console
 				console.error( 'Failed to refresh user record:', error );
 			}
 		}

--- a/settings/src/components/revalidate-modal.js
+++ b/settings/src/components/revalidate-modal.js
@@ -37,7 +37,7 @@ function RevalidateIframe() {
 	const ref = useRef();
 
 	useEffect( () => {
-		function maybeRefreshUser( { data: { type, message } = {} } ) {
+		async function maybeRefreshUser( { data: { type, message } = {} } ) {
 			if ( type !== 'reValidationComplete' ) {
 				return;
 			}
@@ -49,7 +49,12 @@ function RevalidateIframe() {
 			record[ '2fa_revalidation' ].expires_at = new Date().getTime() / 1000 + 3600;
 
 			// Refresh the user record, to fetch the correct 2fa_revalidation data.
-			refreshRecord( userRecord );
+			try {
+				await refreshRecord( userRecord );
+			} catch ( error ) {
+				// TODO: handle error more properly here, likely by showing a error notice
+				console.error( 'Failed to refresh user record:', error );
+			}
 		}
 
 		window.addEventListener( 'message', maybeRefreshUser );

--- a/settings/src/components/revalidate-modal.js
+++ b/settings/src/components/revalidate-modal.js
@@ -1,16 +1,19 @@
 /**
  * WordPress dependencies
  */
-import { useContext, useEffect, useRef } from '@wordpress/element';
+import { useCallback, useContext, useEffect, useRef } from '@wordpress/element';
 import { GlobalContext } from '../script';
 import { Modal } from '@wordpress/components';
 import { useMergeRefs, useFocusableIframe } from '@wordpress/compose';
 import { refreshRecord } from '../utilities';
 
 export default function RevalidateModal() {
-	const { clickScreenLink } = useContext( GlobalContext );
+	const { navigateToScreen } = useContext( GlobalContext );
 
-	const goBack = ( event ) => clickScreenLink( event, 'account-status' );
+	const goBack = useCallback( ( event ) => {
+		event.preventDefault();
+		navigateToScreen( 'account-status' );
+	}, [] );
 
 	return (
 		<Modal

--- a/settings/src/components/screen-link.js
+++ b/settings/src/components/screen-link.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useContext } from '@wordpress/element';
+import { useCallback, useContext } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -9,7 +9,7 @@ import { useContext } from '@wordpress/element';
 import { GlobalContext } from '../script';
 
 export default function ScreenLink( { screen, anchorText, buttonStyle = false, ariaLabel } ) {
-	const { clickScreenLink } = useContext( GlobalContext );
+	const { navigateToScreen } = useContext( GlobalContext );
 	const classes = [];
 	const screenUrl = new URL( document.location.href );
 
@@ -23,10 +23,15 @@ export default function ScreenLink( { screen, anchorText, buttonStyle = false, a
 		classes.push( 'is-secondary' );
 	}
 
+	const onClick = useCallback( ( event ) => {
+		event.preventDefault();
+		navigateToScreen( screen );
+	}, [] );
+
 	return (
 		<a
 			href={ screenUrl.href }
-			onClick={ ( event ) => clickScreenLink( event, screen ) }
+			onClick={ onClick }
 			className={ classes.join( ' ' ) }
 			aria-label={ ariaLabel }
 		>

--- a/settings/src/components/screen-link.js
+++ b/settings/src/components/screen-link.js
@@ -38,10 +38,13 @@ export default function ScreenLink( {
 		classes.push( 'is-secondary' );
 	}
 
-	const onClick = useCallback( ( event ) => {
-		event.preventDefault();
-		navigateToScreen( { currentScreen, nextScreen } );
-	}, [] );
+	const onClick = useCallback(
+		( event ) => {
+			event.preventDefault();
+			navigateToScreen( { currentScreen, nextScreen } );
+		},
+		[ navigateToScreen ]
+	);
 
 	return (
 		<a

--- a/settings/src/components/screen-link.js
+++ b/settings/src/components/screen-link.js
@@ -8,12 +8,27 @@ import { useCallback, useContext } from '@wordpress/element';
  */
 import { GlobalContext } from '../script';
 
-export default function ScreenLink( { screen, anchorText, buttonStyle = false, ariaLabel } ) {
+/**
+ *
+ * @param props
+ * @param props.currentScreen
+ * @param props.nextScreen
+ * @param props.anchorText
+ * @param props.buttonStyle
+ * @param props.ariaLabel
+ */
+export default function ScreenLink( {
+	currentScreen = '',
+	nextScreen,
+	anchorText,
+	buttonStyle = false,
+	ariaLabel,
+} ) {
 	const { navigateToScreen } = useContext( GlobalContext );
 	const classes = [];
 	const screenUrl = new URL( document.location.href );
 
-	screenUrl.searchParams.set( 'screen', screen );
+	screenUrl.searchParams.set( 'screen', nextScreen );
 
 	if ( 'primary' === buttonStyle ) {
 		classes.push( 'components-button' );
@@ -25,7 +40,7 @@ export default function ScreenLink( { screen, anchorText, buttonStyle = false, a
 
 	const onClick = useCallback( ( event ) => {
 		event.preventDefault();
-		navigateToScreen( screen );
+		navigateToScreen( { currentScreen, nextScreen } );
 	}, [] );
 
 	return (

--- a/settings/src/components/screen-navigation.js
+++ b/settings/src/components/screen-navigation.js
@@ -18,7 +18,8 @@ const ScreenNavigation = ( { screen, children } ) => (
 	<Card>
 		<CardHeader className="wporg-2fa__navigation" size="xSmall">
 			<ScreenLink
-				screen="account-status"
+				currentScreen={ screen }
+				nextScreen="account-status"
 				ariaLabel="Back to the account status page"
 				anchorText={
 					<>

--- a/settings/src/components/screen-navigation.js
+++ b/settings/src/components/screen-navigation.js
@@ -1,0 +1,42 @@
+/**
+ * WordPress dependencies
+ */
+import { Icon, chevronLeft } from '@wordpress/icons';
+import { Card, CardHeader, CardBody } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import ScreenLink from './screen-link';
+
+/**
+ * @param props
+ * @param props.children
+ * @param props.screen
+ */
+const ScreenNavigation = ( { screen, children } ) => (
+	<Card>
+		<CardHeader className="wporg-2fa__navigation" size="xSmall">
+			<ScreenLink
+				screen="account-status"
+				ariaLabel="Back to the account status page"
+				anchorText={
+					<>
+						<Icon icon={ chevronLeft } />
+						Back
+					</>
+				}
+			/>
+
+			<h3>
+				{ screen
+					.replace( '-', ' ' )
+					.replace( 'totp', 'Two-Factor Authentication' )
+					.replace( 'webauthn', 'Two-Factor Security Key' ) }
+			</h3>
+		</CardHeader>
+		<CardBody className={ 'wporg-2fa__' + screen }>{ children }</CardBody>
+	</Card>
+);
+
+export default ScreenNavigation;

--- a/settings/src/components/screen-navigation.scss
+++ b/settings/src/components/screen-navigation.scss
@@ -1,0 +1,22 @@
+.wporg-2fa__navigation {
+	padding: 24px 0 !important; /* Override Gutenberg auto-generated. */
+	justify-content: center !important;
+	position: relative;
+
+	a {
+		display: flex;
+    	align-items: center;
+		position: absolute;
+		left: 24px;
+	}
+
+	svg {
+		fill: #4ca6cf;
+	}
+
+	h3 {
+		margin: unset;
+		text-transform: capitalize;
+	}
+
+}

--- a/settings/src/components/tests/utlitites.test.js
+++ b/settings/src/components/tests/utlitites.test.js
@@ -123,8 +123,8 @@ describe( 'refreshRecord', () => {
 		mockRecord.save.mockReset();
 	} );
 
-	it( 'should call edit and save methods on the record object', () => {
-		refreshRecord( mockRecord );
+	it( 'should call edit and save methods on the record object', async () => {
+		await refreshRecord( mockRecord );
 
 		expect( mockRecord.edit ).toHaveBeenCalledWith( {
 			refreshRecordFakeKey: '',

--- a/settings/src/components/tests/utlitites.test.js
+++ b/settings/src/components/tests/utlitites.test.js
@@ -5,6 +5,7 @@
  */
 import { useSelect } from '@wordpress/data';
 import { useEntityRecord } from '@wordpress/core-data';
+import { renderHook } from '@testing-library/react';
 
 /**
  * Local dependencies
@@ -23,7 +24,7 @@ describe( 'useUser', () => {
 	it( 'should call useEntityRecord with correct arguments', () => {
 		useEntityRecord.mockReturnValue( { record: {} } );
 
-		useUser( 1 );
+		renderHook( () => useUser( 1 ) );
 
 		expect( useEntityRecord ).toHaveBeenCalledWith( 'root', 'user', 1 );
 	} );
@@ -32,7 +33,9 @@ describe( 'useUser', () => {
 		useEntityRecord.mockReturnValue( { record: {} } );
 		useSelect.mockReturnValue( true );
 
-		const user = useUser( 1 );
+		const {
+			result: { current: user },
+		} = renderHook( () => useUser( 1 ) );
 
 		expect( useSelect ).toHaveBeenCalled();
 		expect( user.isSaving ).toBeTruthy();
@@ -43,7 +46,9 @@ describe( 'useUser', () => {
 			record: { password: 'test-password' },
 		} );
 
-		const user = useUser( 1 );
+		const {
+			result: { current: user },
+		} = renderHook( () => useUser( 1 ) );
 
 		expect( user.userRecord.record.password ).toBe( 'test-password' );
 	} );
@@ -51,7 +56,9 @@ describe( 'useUser', () => {
 	it( 'should set hasPrimaryProvider to false if user.userRecord.record is undefined', () => {
 		useEntityRecord.mockReturnValue( {} );
 
-		const user = useUser( 1 );
+		const {
+			result: { current: user },
+		} = renderHook( () => useUser( 1 ) );
 
 		expect( user.hasPrimaryProvider ).toBe( false );
 	} );
@@ -59,7 +66,9 @@ describe( 'useUser', () => {
 	it( 'should set hasPrimaryProvider to false if 2fa_available_providers is undefined', () => {
 		useEntityRecord.mockReturnValue( { record: {} } );
 
-		const user = useUser( 1 );
+		const {
+			result: { current: user },
+		} = renderHook( () => useUser( 1 ) );
 
 		expect( user.hasPrimaryProvider ).toBe( false );
 	} );
@@ -67,7 +76,9 @@ describe( 'useUser', () => {
 	it( 'should set hasPrimaryProvider to false if 2fa_available_providers is empty', () => {
 		useEntityRecord.mockReturnValue( { record: { '2fa_available_providers': [] } } );
 
-		const user = useUser( 1 );
+		const {
+			result: { current: user },
+		} = renderHook( () => useUser( 1 ) );
 
 		expect( user.hasPrimaryProvider ).toBe( false );
 	} );
@@ -77,7 +88,9 @@ describe( 'useUser', () => {
 			record: { '2fa_available_providers': [ 'Two_Factor_Backup_Codes' ] },
 		} );
 
-		const user = useUser( 1 );
+		const {
+			result: { current: user },
+		} = renderHook( () => useUser( 1 ) );
 
 		expect( user.hasPrimaryProvider ).toBe( false );
 	} );
@@ -87,7 +100,9 @@ describe( 'useUser', () => {
 			record: { '2fa_available_providers': [ 'Two_Factor_Totp', 'Two_Factor_Backup_Codes' ] },
 		} );
 
-		const user = useUser( 1 );
+		const {
+			result: { current: user },
+		} = renderHook( () => useUser( 1 ) );
 
 		expect( user.hasPrimaryProvider ).toBe( true );
 	} );
@@ -102,7 +117,9 @@ describe( 'useUser', () => {
 			},
 		} );
 
-		const user = useUser( 1 );
+		const {
+			result: { current: user },
+		} = renderHook( () => useUser( 1 ) );
 
 		expect( user.hasPrimaryProvider ).toBe( true );
 	} );

--- a/settings/src/components/totp.js
+++ b/settings/src/components/totp.js
@@ -74,7 +74,7 @@ function Setup() {
 				},
 			} );
 
-			refreshRecord( userRecord );
+			await refreshRecord( userRecord );
 			clickScreenLink( event, 'backup-codes' );
 			setGlobalNotice( 'Successfully enabled One Time Passwords.' ); // Must be After `clickScreenEvent` clears it.
 		} catch ( handleEnableError ) {
@@ -304,7 +304,7 @@ function Manage() {
 				data: { user_id: userRecord.record.id },
 			} );
 
-			refreshRecord( userRecord );
+			await refreshRecord( userRecord );
 			setGlobalNotice( 'Successfully disabled One Time Passwords.' );
 		} catch ( handleDisableError ) {
 			setError( handleDisableError.message );

--- a/settings/src/components/totp.js
+++ b/settings/src/components/totp.js
@@ -75,7 +75,7 @@ function Setup() {
 			} );
 
 			await refreshRecord( userRecord );
-			clickScreenLink( event, 'backup-codes' );
+			clickScreenLink( { event, nextScreen: 'backup-codes' } );
 			setGlobalNotice( 'Successfully enabled One Time Passwords.' ); // Must be After `clickScreenEvent` clears it.
 		} catch ( handleEnableError ) {
 			setError( handleEnableError.message );
@@ -321,8 +321,8 @@ function Manage() {
 
 			<p>
 				Make sure you&apos;ve created{ ' ' }
-				<ScreenLink screen="backup-codes" anchorText="backup codes" /> and saved them in a
-				safe location, in case you ever lose your device. You may also need them when
+				<ScreenLink nextScreen="backup-codes" anchorText="backup codes" /> and saved them in
+				a safe location, in case you ever lose your device. You may also need them when
 				transitioning to a new device. Without them you may permanently lose access to your
 				account.
 			</p>

--- a/settings/src/script.js
+++ b/settings/src/script.js
@@ -114,10 +114,8 @@ function Main( { userId } ) {
 	 * This is used in conjunction with real links in order to preserve deep linking and other foundational
 	 * behaviors that are broken otherwise.
 	 */
-	const clickScreenLink = useCallback(
-		( event, nextScreen ) => {
-			event.preventDefault();
-
+	const navigateToScreen = useCallback(
+		( nextScreen ) => {
 			// Reset to initial after navigating away from a page.
 			// Note: password was initially not in record, this would prevent incomplete state
 			// from resetting when leaving the password setting page.
@@ -185,7 +183,7 @@ function Main( { userId } ) {
 	}
 
 	return (
-		<GlobalContext.Provider value={ { clickScreenLink, user, setGlobalNotice } }>
+		<GlobalContext.Provider value={ { navigateToScreen, user, setGlobalNotice } }>
 			<GlobalNotice notice={ globalNotice } setNotice={ setGlobalNotice } />
 			{ screenContent }
 		</GlobalContext.Provider>

--- a/settings/src/script.js
+++ b/settings/src/script.js
@@ -58,6 +58,8 @@ function Main( { userId } ) {
 	const {
 		userRecord: { record, edit, hasEdits, hasResolved },
 		hasPrimaryProvider,
+		hasBackupCodesPrinted,
+		setHasBackupCodesPrinted,
 	} = user;
 	const [ globalNotice, setGlobalNotice ] = useState( '' );
 	const [ error, setError ] = useState( '' );
@@ -165,7 +167,15 @@ function Main( { userId } ) {
 
 	return (
 		<GlobalContext.Provider
-			value={ { navigateToScreen, user, setGlobalNotice, setError, error } }
+			value={ {
+				navigateToScreen,
+				user,
+				setGlobalNotice,
+				setError,
+				error,
+				hasBackupCodesPrinted,
+				setHasBackupCodesPrinted,
+			} }
 		>
 			<GlobalNotice notice={ globalNotice } setNotice={ setGlobalNotice } />
 			{ currentScreenComponent }

--- a/settings/src/script.js
+++ b/settings/src/script.js
@@ -121,15 +121,21 @@ function Main( { userId } ) {
 	 */
 	const navigateToScreen = useCallback(
 		( { currentScreen, nextScreen } ) => {
-			// If there's already another error, do not overwrite it with the error below.
-			// Because usually, if there are other errors, it means there's a problem with the backup code generation.
-			// When this happens, users shouldn't need to confirm the checkbox to leave the current screen.
-			if ( 'backup-codes' === currentScreen && ! error && ! hasBackupCodesPrinted ) {
-				setError( {
-					code: 'checkbox_confirmation_required',
-					message: 'Confirmation is required. Please check the checkbox to continue.',
-				} );
-				return;
+			if ( 'backup-codes' === currentScreen ) {
+				// If there's already another error, do not overwrite it with the error below.
+				// Because usually, if there are other errors, it means there's a problem with the backup code generation.
+				// When this happens, users shouldn't need to confirm the checkbox to leave the current screen.
+				if ( ! error && ! hasBackupCodesPrinted ) {
+					setError( {
+						code: 'checkbox_confirmation_required',
+						message: 'Confirmation is required. Please check the checkbox to continue.',
+					} );
+					return;
+				}
+
+				if ( error.code === 'checkbox_confirmation_required' ) {
+					return;
+				}
 			}
 
 			// Reset to initial after navigating away from a page.

--- a/settings/src/script.js
+++ b/settings/src/script.js
@@ -113,9 +113,16 @@ function Main( { userId } ) {
 	 *
 	 * This is used in conjunction with real links in order to preserve deep linking and other foundational
 	 * behaviors that are broken otherwise.
+	 *
+	 * @param currentScreen Optional. Only needed when you'd like to do some processing on the current screen before navigating away.
+	 * @param nextScreen    Next screen you're navigating to
 	 */
 	const navigateToScreen = useCallback(
-		( nextScreen ) => {
+		( { currentScreen, nextScreen } ) => {
+			if ( 'backup-codes' === currentScreen ) {
+				// TODO
+			}
+
 			// Reset to initial after navigating away from a page.
 			// Note: password was initially not in record, this would prevent incomplete state
 			// from resetting when leaving the password setting page.

--- a/settings/src/script.js
+++ b/settings/src/script.js
@@ -121,7 +121,10 @@ function Main( { userId } ) {
 	 */
 	const navigateToScreen = useCallback(
 		( { currentScreen, nextScreen } ) => {
-			if ( 'backup-codes' === currentScreen && ! hasBackupCodesPrinted ) {
+			// If there's already another error, do not overwrite it with the error below.
+			// Because usually, if there are other errors, it means there's a problem with the backup code generation.
+			// When this happens, users shouldn't need to confirm the checkbox to leave the current screen.
+			if ( 'backup-codes' === currentScreen && ! error && ! hasBackupCodesPrinted ) {
 				setError( {
 					code: 'checkbox_confirmation_required',
 					message: 'Confirmation is required. Please check the checkbox to continue.',
@@ -148,7 +151,7 @@ function Main( { userId } ) {
 			setGlobalNotice( '' );
 			setScreen( nextScreen );
 		},
-		[ hasEdits, hasBackupCodesPrinted ]
+		[ hasEdits, hasBackupCodesPrinted, error ]
 	);
 
 	if ( ! hasResolved ) {

--- a/settings/src/script.js
+++ b/settings/src/script.js
@@ -121,8 +121,12 @@ function Main( { userId } ) {
 	 */
 	const navigateToScreen = useCallback(
 		( { currentScreen, nextScreen } ) => {
-			if ( 'backup-codes' === currentScreen ) {
-				// TODO
+			if ( 'backup-codes' === currentScreen && ! hasBackupCodesPrinted ) {
+				setError( {
+					code: 'checkbox_confirmation_required',
+					message: 'Confirmation is required. Please check the checkbox to continue.',
+				} );
+				return;
 			}
 
 			// Reset to initial after navigating away from a page.
@@ -144,7 +148,7 @@ function Main( { userId } ) {
 			setGlobalNotice( '' );
 			setScreen( nextScreen );
 		},
-		[ hasEdits ]
+		[ hasEdits, hasBackupCodesPrinted ]
 	);
 
 	if ( ! hasResolved ) {

--- a/settings/src/script.js
+++ b/settings/src/script.js
@@ -63,6 +63,8 @@ function Main( { userId } ) {
 	const [ globalNotice, setGlobalNotice ] = useState( '' );
 
 	let currentUrl = new URL( document.location.href );
+	let initialScreen = currentUrl.searchParams.get( 'screen' );
+	const [ screen, setScreen ] = useState( initialScreen );
 
 	// The index is the URL slug and the value is the React component.
 	const components = {
@@ -70,7 +72,7 @@ function Main( { userId } ) {
 		email: <EmailAddress />,
 		password: <Password />,
 		totp: <TOTP />,
-		'backup-codes': <BackupCodes />,
+		'backup-codes': <BackupCodes setScreen={ setScreen } />,
 	};
 
 	// TODO: Only enable WebAuthn UI in development, until it's finished.
@@ -81,16 +83,11 @@ function Main( { userId } ) {
 	// The screens where a recent two factor challenge is required.
 	const twoFactorRequiredScreens = [ 'webauthn', 'totp', 'backup-codes' ];
 
-	let initialScreen = currentUrl.searchParams.get( 'screen' );
-
 	if ( ! components[ initialScreen ] ) {
 		initialScreen = 'account-status';
 		currentUrl.searchParams.set( 'screen', initialScreen );
 		window.history.pushState( {}, '', currentUrl );
 	}
-
-	const [ screen, setScreen ] = useState( initialScreen );
-	const currentScreen = components[ screen ];
 
 	// Listen for back/forward button clicks.
 	useEffect( () => {
@@ -146,6 +143,7 @@ function Main( { userId } ) {
 		return <Spinner />;
 	}
 
+	const currentScreen = components[ screen ];
 	let screenContent = currentScreen;
 
 	if ( 'account-status' !== screen ) {

--- a/settings/src/script.js
+++ b/settings/src/script.js
@@ -132,6 +132,7 @@ function Main( { userId } ) {
 			currentUrl.searchParams.set( 'screen', nextScreen );
 			window.history.pushState( {}, '', currentUrl );
 
+			setError( '' );
 			setGlobalNotice( '' );
 			setScreen( nextScreen );
 		},

--- a/settings/src/script.js
+++ b/settings/src/script.js
@@ -170,18 +170,14 @@ function Main( { userId } ) {
 				<CardBody className={ 'wporg-2fa__' + screen }>{ currentScreen }</CardBody>
 			</Card>
 		);
-	} else if (
+	}
+
+	const isRevalidationExpired =
 		twoFactorRequiredScreens.includes( screen ) &&
 		hasPrimaryProvider &&
-		record[ '2fa_revalidation' ]?.expires_at <= new Date().getTime() / 1000
-	) {
-		screenContent = (
-			<>
-				{ currentScreen }
-				<RevalidateModal />
-			</>
-		);
-	}
+		record[ '2fa_revalidation' ]?.expires_at <= new Date().getTime() / 1000;
+
+	const shouldRevalidate = 'revalidation_required' === error.code || isRevalidationExpired;
 
 	return (
 		<GlobalContext.Provider
@@ -189,7 +185,7 @@ function Main( { userId } ) {
 		>
 			<GlobalNotice notice={ globalNotice } setNotice={ setGlobalNotice } />
 			{ screenContent }
-			{ 'revalidation_required' === error.code && <RevalidateModal /> }
+			{ shouldRevalidate && <RevalidateModal /> }
 		</GlobalContext.Provider>
 	);
 }

--- a/settings/src/script.js
+++ b/settings/src/script.js
@@ -9,14 +9,13 @@ import {
 	useState,
 	createRoot,
 } from '@wordpress/element';
-import { Icon, chevronLeft } from '@wordpress/icons';
-import { Card, CardHeader, CardBody, Spinner } from '@wordpress/components';
+import { Spinner } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import { useUser } from './utilities';
-import ScreenLink from './components/screen-link';
+import ScreenNavigation from './components/screen-navigation';
 import AccountStatus from './components/account-status';
 import Password from './components/password';
 import EmailAddress from './components/email-address';
@@ -143,35 +142,12 @@ function Main( { userId } ) {
 		return <Spinner />;
 	}
 
-	const currentScreen = components[ screen ];
-	let screenContent = currentScreen;
-
-	if ( 'account-status' !== screen ) {
-		screenContent = (
-			<Card>
-				<CardHeader className="wporg-2fa__navigation" size="xSmall">
-					<ScreenLink
-						screen="account-status"
-						ariaLabel="Back to the account status page"
-						anchorText={
-							<>
-								<Icon icon={ chevronLeft } />
-								Back
-							</>
-						}
-					/>
-
-					<h3>
-						{ screen
-							.replace( '-', ' ' )
-							.replace( 'totp', 'Two-Factor Authentication' )
-							.replace( 'webauthn', 'Two-Factor Security Key' ) }
-					</h3>
-				</CardHeader>
-				<CardBody className={ 'wporg-2fa__' + screen }>{ currentScreen }</CardBody>
-			</Card>
+	const currentScreenComponent =
+		'account-status' === screen ? (
+			components[ screen ]
+		) : (
+			<ScreenNavigation screen={ screen }>{ components[ screen ] }</ScreenNavigation>
 		);
-	}
 
 	const isRevalidationExpired =
 		twoFactorRequiredScreens.includes( screen ) &&
@@ -185,7 +161,7 @@ function Main( { userId } ) {
 			value={ { navigateToScreen, user, setGlobalNotice, setError, error } }
 		>
 			<GlobalNotice notice={ globalNotice } setNotice={ setGlobalNotice } />
-			{ screenContent }
+			{ currentScreenComponent }
 			{ shouldRevalidate && <RevalidateModal /> }
 		</GlobalContext.Provider>
 	);

--- a/settings/src/script.js
+++ b/settings/src/script.js
@@ -61,6 +61,7 @@ function Main( { userId } ) {
 		hasPrimaryProvider,
 	} = user;
 	const [ globalNotice, setGlobalNotice ] = useState( '' );
+	const [ error, setError ] = useState( '' );
 
 	let currentUrl = new URL( document.location.href );
 	let initialScreen = currentUrl.searchParams.get( 'screen' );
@@ -183,9 +184,12 @@ function Main( { userId } ) {
 	}
 
 	return (
-		<GlobalContext.Provider value={ { navigateToScreen, user, setGlobalNotice } }>
+		<GlobalContext.Provider
+			value={ { navigateToScreen, user, setGlobalNotice, setError, error } }
+		>
 			<GlobalNotice notice={ globalNotice } setNotice={ setGlobalNotice } />
 			{ screenContent }
+			{ 'revalidation_required' === error.code && <RevalidateModal /> }
 		</GlobalContext.Provider>
 	);
 }

--- a/settings/src/script.js
+++ b/settings/src/script.js
@@ -59,7 +59,6 @@ function Main( { userId } ) {
 		userRecord: { record, edit, hasEdits, hasResolved },
 		hasPrimaryProvider,
 		hasBackupCodesPrinted,
-		setHasBackupCodesPrinted,
 	} = user;
 	const [ globalNotice, setGlobalNotice ] = useState( '' );
 	const [ error, setError ] = useState( '' );
@@ -186,8 +185,6 @@ function Main( { userId } ) {
 				setGlobalNotice,
 				setError,
 				error,
-				hasBackupCodesPrinted,
-				setHasBackupCodesPrinted,
 			} }
 		>
 			<GlobalNotice notice={ globalNotice } setNotice={ setGlobalNotice } />

--- a/settings/src/style.scss
+++ b/settings/src/style.scss
@@ -50,29 +50,6 @@ $alert-blue: #72aee6;
 	flex-wrap: wrap;
 }
 
-.wporg-2fa__navigation {
-	padding: 24px 0 !important; /* Override Gutenberg auto-generated. */
-	justify-content: center !important;
-	position: relative;
-
-	a {
-		display: flex;
-    	align-items: center;
-		position: absolute;
-		left: 24px;
-	}
-
-	svg {
-		fill: #4ca6cf;
-	}
-
-	h3 {
-		margin: unset;
-		text-transform: capitalize;
-	}
-
-}
-
 .wporg-2fa__token {
 	letter-spacing: .3em;
 }
@@ -105,5 +82,6 @@ $alert-blue: #72aee6;
 @import "components/setup-progress-bar";
 @import "components/global-notice";
 @import "components/screen-link";
+@import "components/screen-navigation";
 @import "components/auto-tabbing-input";
 @import "components/revalidate-modal";

--- a/settings/src/utilities.js
+++ b/settings/src/utilities.js
@@ -1,5 +1,6 @@
 import { useSelect } from '@wordpress/data';
 import { store as coreDataStore, useEntityRecord } from '@wordpress/core-data';
+import { useState } from '@wordpress/element';
 
 /**
  * Get the user.
@@ -8,6 +9,7 @@ import { store as coreDataStore, useEntityRecord } from '@wordpress/core-data';
  */
 export function useUser( userId ) {
 	const userRecord = useEntityRecord( 'root', 'user', userId );
+	const [ hasBackupCodesPrinted, setHasBackupCodesPrinted ] = useState( false );
 	const isSaving = useSelect( ( select ) =>
 		select( coreDataStore ).isSavingEntityRecord( 'root', 'user', userId )
 	);
@@ -25,6 +27,8 @@ export function useUser( userId ) {
 		totpEnabled,
 		backupCodesEnabled,
 		webAuthnEnabled,
+		hasBackupCodesPrinted,
+		setHasBackupCodesPrinted,
 	};
 }
 


### PR DESCRIPTION
Fixes #190

This PR ensures that users cannot leave the Backup Codes screen by pressing `Back` without checking `I have printed or saved these codes`, and at the same time, prompt a Notice to remind users that they should confirm the checkbox before proceeding with other actions.

[ScreenNavigation was extracted](https://github.com/WordPress/wporg-two-factor/pull/205/commits/22b3e6c234142eea2724f4adb5b2fff2fedfeeb1) was done to make the subsequent commits easier to modify and read.

[hasPrinted was extracted to useUser](https://github.com/WordPress/wporg-two-factor/pull/205/commits/27ed028ecc030eac93e74fbf012098c1a0912a42) so that `navigateToScreen` can access it.

## Screencast

No other errors in BackupCodes component exist

https://github.com/WordPress/wporg-two-factor/assets/18050944/d9de3af7-e325-48a7-a37f-ce9f6fd03091

Other errors in BackupCodes component exist

https://github.com/WordPress/wporg-two-factor/assets/18050944/75dc36b1-508e-4121-bc78-b5bb5f7c05fc

## Testing Steps

1. Test in a Sandbox.
2. enable 2fa.
3. Go to backup codes and you can't `Back` if you don't confirm the checkbox, and an error Notice should prompt.
4. Go to `wp-content/plugins/two-factor/providers/class-two-factor-backup-codes.php` and make it always throw an error on L295.
5. Go to backup codes and you can click `Back`.