### PR TITLE
Fix JS test failure due to undefined `wp`

### DIFF
--- a/settings/src/components/webauthn/list-keys.js
+++ b/settings/src/components/webauthn/list-keys.js
@@ -12,11 +12,6 @@ import { GlobalContext } from '../../script';
 import { refreshRecord } from '../../utilities';
 
 /**
- * Global dependencies
- */
-const ajax = wp.ajax;
-
-/**
  * Render the list of keys.
  */
 export default function ListKeys() {
@@ -37,7 +32,7 @@ export default function ListKeys() {
 		setDeleting( true );
 
 		try {
-			await ajax.post( 'webauthn_delete_key', {
+			await wp.ajax.post( 'webauthn_delete_key', {
 				user_id: userRecord.record.id,
 				handle: modalKey.credential_id,
 				_ajax_nonce: modalKey.delete_nonce,


### PR DESCRIPTION
Fixes #206

Remove reference to `wp` outside of component to fix undefined in password.test.js