### PR TITLE
Enable WebAuthn when registering the first key

### DIFF
--- a/settings/src/components/webauthn/register-key.js
+++ b/settings/src/components/webauthn/register-key.js
@@ -141,10 +141,13 @@ function WaitingForSecurityKey() {
  * @param props.afterTimeout
  */
 function Success( { newKeyName, afterTimeout } ) {
-	// TODO need to sync this with the animation
-	setTimeout( () => {
-		afterTimeout();
-	}, 2000 );
+	const [ hasTimer, setHasTimer ] = useState( false );
+
+	if ( ! hasTimer ) {
+		// TODO need to sync this timing with the animation below
+		setTimeout( afterTimeout, 2000 );
+		setHasTimer( true );
+	}
 
 	return (
 		<>


### PR DESCRIPTION
See #193 

This enables the WebAuthn provider after a user registers their first key. It focuses on the functionality since the design will be refined in #194.

### Testing:

1. Disable WebAuthn provider on `wp-admin/profile.php`
2. Register a key
3. Refresh `profile.php` to see that it's now enabled
