### PR TITLE
Only show `ListKeys` when keys are registered

### DIFF
--- a/settings/src/components/webauthn/webauthn.js
+++ b/settings/src/components/webauthn/webauthn.js
@@ -21,6 +21,10 @@ const alert = window.alert;
  * Render the WebAuthn setting.
  */
 export default function WebAuthn() {
+	const {
+		user: { userRecord },
+	} = useContext( GlobalContext );
+	const keys = userRecord.record[ '2fa_webauthn_keys' ];
 	const { webAuthnEnabled, backupCodesEnabled } = useContext( GlobalContext );
 	const [ flow, setFlow ] = useState( 'manage' );
 
@@ -87,19 +91,25 @@ export default function WebAuthn() {
 				security than passwords alone.
 			</p>
 
-			<h4>Security Keys</h4>
+			{ keys.length > 0 && (
+				<>
+					<h4>Security Keys</h4>
 
-			<ListKeys />
+					<ListKeys />
+				</>
+			) }
 
 			<p className="wporg-2fa__submit-actions">
 				<Button variant="primary" onClick={ () => setFlow( 'register' ) }>
 					Register New Key
 				</Button>
 
-				<Button variant="secondary" onClick={ disableProvider }>
-					Disable Security Keys
-					{ /* TODO change this to Enable if the provider is disabled? */ }
-				</Button>
+				{ keys.length > 0 && (
+					<Button variant="secondary" onClick={ disableProvider }>
+						Disable Security Keys
+						{ /* TODO change this to Enable if the provider is disabled? */ }
+					</Button>
+				) }
 			</p>
 		</>
 	);


### PR DESCRIPTION
See #194 

This hides `ListKeys` and the enable/disable provider buttons, since they don't make sense when there aren't any keys registered. The UI looks cleaner without them.

| Before | After |
|--------|--------|
| <img width="856" alt="Screenshot 2023-06-07 at 3 06 43 PM" src="https://github.com/WordPress/wporg-two-factor/assets/484068/d817f44a-c015-4319-93d0-8215a476b194"> | <img width="855" alt="Screenshot 2023-06-07 at 3 06 22 PM" src="https://github.com/WordPress/wporg-two-factor/assets/484068/b541612f-5da9-430b-83fd-44e33d56925a"> | 