### PR TITLE
Add primary provider indicator badge

### DIFF
--- a/settings/rest-api.php
+++ b/settings/rest-api.php
@@ -165,6 +165,22 @@ function register_user_fields(): void {
 
 	register_rest_field(
 		'user',
+		'2fa_primary_provider',
+		[
+			'get_callback' => function( $user ) {
+				$provider = Two_Factor_Core::get_primary_provider_for_user( get_userdata( $user['id'] ) );
+
+				return is_a( $provider, 'Two_Factor_Provider' ) ? $provider->get_key() : null;
+			},
+			'schema' => [
+				'type'    => 'array',
+				'context' => [ 'edit' ],
+			]
+		]
+	);
+
+	register_rest_field(
+		'user',
 		'2fa_backup_codes_remaining',
 		[
 			'get_callback' => function( $user ) {

--- a/settings/src/components/account-status.js
+++ b/settings/src/components/account-status.js
@@ -21,6 +21,7 @@ export default function AccountStatus() {
 				record: { email, pending_email: pendingEmail },
 			},
 			hasPrimaryProvider,
+			primaryProvider,
 			totpEnabled,
 			backupCodesEnabled,
 			webAuthnEnabled,
@@ -60,7 +61,12 @@ export default function AccountStatus() {
 				<SettingStatusCard
 					screen="webauthn"
 					status={ hasPrimaryProvider && ! webAuthnEnabled ? 'info' : webAuthnEnabled }
-					headerText="Two-Factor Security Key"
+					headerText={
+						'Two-Factor Security Key' +
+						( 'TwoFactor_Provider_WebAuthn' === primaryProvider && totpEnabled
+							? ' (Default)'
+							: '' )
+					}
 					bodyText={
 						webAuthnEnabled
 							? 'You have two-factor authentication enabled using security keys.'
@@ -72,7 +78,10 @@ export default function AccountStatus() {
 			<SettingStatusCard
 				screen="totp"
 				status={ hasPrimaryProvider && ! totpEnabled ? 'info' : totpEnabled }
-				headerText="Two-Factor App"
+				headerText={
+					'Two-Factor App' +
+					( 'Two_Factor_Totp' === primaryProvider && webAuthnEnabled ? ' (Default)' : '' )
+				}
 				bodyText={
 					totpEnabled
 						? 'You have two-factor authentication enabled using an app.'
@@ -105,10 +114,13 @@ function SettingStatusCard( { screen, status, headerText, bodyText, disabled = f
 	const cardContent = (
 		<CardBody>
 			<StatusIcon status={ status } />
+
 			<h3 aria-label={ 'Click to enter the ' + headerText + ' setting page.' }>
 				{ headerText }
 			</h3>
-			<p>{ bodyText }</p>
+
+			<p className="wporg-2fa__status-card-body">{ bodyText }</p>
+
 			<Icon icon={ chevronRight } size={ 26 } className="wporg-2fa__status-card-open" />
 		</CardBody>
 	);

--- a/settings/src/components/account-status.scss
+++ b/settings/src/components/account-status.scss
@@ -45,7 +45,7 @@
 				color: $gray-900;
 			}
 
-			p {
+			.wporg-2fa__status-card-body {
 				grid-area: description;
 				align-self: start;
 				margin: 0;

--- a/settings/src/utilities.js
+++ b/settings/src/utilities.js
@@ -13,6 +13,7 @@ export function useUser( userId ) {
 	);
 
 	const availableProviders = userRecord.record?.[ '2fa_available_providers' ] ?? [];
+	const primaryProvider = userRecord.record?.[ '2fa_primary_provider' ] ?? null;
 	const totpEnabled = availableProviders.includes( 'Two_Factor_Totp' );
 	const backupCodesEnabled = availableProviders.includes( 'Two_Factor_Backup_Codes' );
 	const webAuthnEnabled = availableProviders.includes( 'TwoFactor_Provider_WebAuthn' );
@@ -22,6 +23,7 @@ export function useUser( userId ) {
 		userRecord: { ...userRecord },
 		isSaving,
 		hasPrimaryProvider,
+		primaryProvider,
 		totpEnabled,
 		backupCodesEnabled,
 		webAuthnEnabled,


### PR DESCRIPTION
See #194 

This adds a badge to indicate which provider is the primary/default. I choose "default" because that seems more intuitive for users. 

I couldn't find any other badges in Figma to reference, so I just tried to make it decent. @jasmussen If you're aware of any, or want to make one, let me know.


* Only one ordinary provider active - no change because an indicator isn't needed
    <img width="773" alt="Screenshot 2023-06-08 at 2 53 27 PM" src="https://github.com/WordPress/wporg-two-factor/assets/484068/d4af0344-03a7-4a8f-b2d6-49272ecbd5e8">
* Two ordinary providers active - badge shows to indicate default
    <img width="364" alt="Screenshot 2023-06-08 at 3 29 05 PM" src="https://github.com/WordPress/wporg-two-factor/assets/484068/a6c54e7a-0eaa-4630-8d79-12d762b992f5">

    <img width="744" alt="Screenshot 2023-06-08 at 3 29 44 PM" src="https://github.com/WordPress/wporg-two-factor/assets/484068/b0f7f16a-4e91-488c-bdae-8ef214306687">
