### PR TITLE
Fix unable to see the first set of backup codes after enabling the 2FA

### DIFF
--- a/settings/src/components/backup-codes.js
+++ b/settings/src/components/backup-codes.js
@@ -33,6 +33,10 @@ export default function BackupCodes() {
 		return;
 	}
 
+	// TODO: record.isSetupFinished and its related logic should be removed
+	// once https://github.com/WordPress/two-factor/issues/507 is fixed.
+	// This is a workaround that fixes the side effect brought up by #507.
+	// See more in https://github.com/WordPress/wporg-two-factor/issues/216 and its PR.
 	if ( backupCodesEnabled && record.isSetupFinished && ! regenerating ) {
 		return <Manage setRegenerating={ setRegenerating } />;
 	}


### PR DESCRIPTION
Fixes #216, and the behavior of #190 is changed.

This PR adds `isSetupFinished` to `record`. 
It could fix the issue - Unable to see the first set of backup codes after enabling the 2FA,
and also somewhat change the problem raised in https://github.com/WordPress/wporg-two-factor/issues/190, as the flow after the fix here is something like 

* If users don't click the `All finish` button and go back to account screen -> the backup code button status _is_ updated as enabled and clickable (This wasn't fixed by this PR, and actually this is related to the issue of this PR - **the root cause for "as soon as the codes are generated, the screen gets directed to `Manage` screen" is that the `backupCodesEnabled` [here](https://github.com/WordPress/wporg-two-factor/blob/trunk/settings/src/components/backup-codes.js#L24) has already been set to `true`, and this makes the issue in #190 go away.** i.e., the backup code button status is updated as enabled and clickable) 
However, even though the issue from #190 is resolved, another similar problem has popped up. The status on the account-status screen should _not_ be set to enabled. This is because, after the fix implemented in this PR, there might be some confusion. For instance, (1) if users don't click `All finish` and directly navigate back to the account screen, they would see that the backup codes are enabled. This could be misleading. Similarly, (2) if users have already activated their backup codes once, they might out of curiosity or by accident click the generate new codes button. At this point, since they don't really intend to generate new codes, they might just click `Back` to leave the screen, or even log out, thinking they could still use the backup codes that they activated earlier - which they couldn't. Therefore, the status _shouldn't_ be set to `enabled`, but at the same time, it _shouldn't_ prevent users from clicking it as well. We could handle this in another PR.

* If users click the `All finish` button and go back to account screen ->  the status _is_ correctly updated (enabled and clickable)

For more details about flow please see the screencast below.

This workaround may not seem ideal, but other methods like adding state or using the apiFetch middleware don't really handle all the cases quite well. Once the [upstream PR](https://github.com/WordPress/two-factor/issues/507) is fixed, this can be removed. At that point, we will have the ability to decide when `backupCodesEnabled` should be enabled and control the state.

## Screencast

https://github.com/WordPress/wporg-two-factor/assets/18050944/bc3378ba-30fe-44fe-acb2-fd312cc8d6a0

## Testing Step

1. Set up 2FA while sandboxed.
2. When 2FA is successfully activated, see if it redirects to backup codes screen and stays there, if so, this issue is fixed.
