### PR TITLE
Fix unable to see the first set of backup code - using localStroage

### DIFF
--- a/settings/.eslintrc.js
+++ b/settings/.eslintrc.js
@@ -2,6 +2,10 @@ module.exports = {
 	root: true,
 	extends: 'plugin:@wordpress/eslint-plugin/recommended',
 
+	env: {
+		browser: true,
+	},
+
 	globals: { navigator: 'readonly' },
 
 	rules: {


### PR DESCRIPTION
Fixes https://github.com/WordPress/wporg-two-factor/issues/216
Clear comparison without disturbance from reverting: https://github.com/WordPress/wporg-two-factor/compare/2f6c51e7571c738cf196e699797359597514b6cd...fix/Unable-to-see-the-first-set-of-backup-code

Before deploying #217, more cases were tested and a missing scenario was found: when leaving the account page and returning, the `isSetupFinished` state gets reset (as the 2FA component is unmounted), which leads to the direct generation of new backup codes upon entering the backup-codes screen again. Initially, I didn't want to use localStorage due to the concerns mentieond below. However, it appears an efficient way to reoslve this issue.

But if we feel that the troubles caused by these concerns outweigh the inconvenience of not being able to see the first set of codes and considering that the upstream issue [#507](https://github.com/WordPress/two-factor/issues/507) can reach a consensus and be fixed soon, then I believe no modifications are necessary for addressing this issue.

Concerns about localStorage
* localStorage has no expiry date: We will need to remove the key from localStorage in our next release by using `localStorage.removeItem('key')` once we don't the key anymore.
* If a user chooses to clear browser storage data, such as cookies and site data, information in localStorage will also be cleared.
* LocalStorage is bound to a specific browser. The state will disappear if switching browsers.