### PR TITLE
Add success animation to security key and TOTP flows

### DIFF
--- a/settings/src/components/success.js
+++ b/settings/src/components/success.js
@@ -1,0 +1,36 @@
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+import { Icon, check } from '@wordpress/icons';
+
+/**
+ * Render the "Success" component.
+ *
+ * Shows a message and animation, then calls the `afterTimeout` callback
+ *
+ * @param props
+ * @param props.afterTimeout
+ * @param props.message
+ */
+export default function Success( { message, afterTimeout } ) {
+	const [ hasTimer, setHasTimer ] = useState( false );
+
+	if ( ! hasTimer ) {
+		// Time matches the length of the CSS animation property on .wporg-2fa__success
+		setTimeout( afterTimeout, 4000 );
+		setHasTimer( true );
+	}
+
+	return (
+		<>
+			<p className="wporg-2fa__screen-intro">{ message }</p>
+
+			<p className="wporg-2fa__webauthn-register-key-status" aria-hidden>
+				<div className="wporg-2fa__success">
+					<Icon icon={ check } />
+				</div>
+			</p>
+		</>
+	);
+}

--- a/settings/src/components/success.scss
+++ b/settings/src/components/success.scss
@@ -1,0 +1,29 @@
+@keyframes success {
+	0% {
+		transform: scale(0);
+	}
+	10% {
+		transform: scale(1.5);
+	}
+	20% {
+		transform: scale(1);
+	}
+	80% {
+		transform: scale(1);
+	}
+	100% {
+		transform: scale(0);
+	}
+}
+
+.wporg-2fa__success {
+	transform: scale(0);
+	background: #33F078;
+	border-radius: 50%;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 32px;
+	height: 32px;
+	animation: success 4s ease-in-out;
+}

--- a/settings/src/components/webauthn/register-key.js
+++ b/settings/src/components/webauthn/register-key.js
@@ -3,7 +3,7 @@
  */
 import { Button, Notice, Spinner, TextControl } from '@wordpress/components';
 import { useCallback, useContext, useState } from '@wordpress/element';
-import { Icon, check, cancelCircleFilled } from '@wordpress/icons';
+import { Icon, cancelCircleFilled } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -14,6 +14,7 @@ import {
 	preparePublicKeyCreationOptions,
 	preparePublicKeyCredential,
 } from '../../utilities/webauthn';
+import Success from '../success';
 
 /**
  * Render the form to register new security keys.
@@ -77,7 +78,12 @@ export default function RegisterKey( { onSuccess, onCancel } ) {
 	}
 
 	if ( 'success' === step ) {
-		return <Success newKeyName={ keyName } afterTimeout={ onSuccess } />;
+		return (
+			<Success
+				message={ `Success! Your ${ keyName } is successfully registered.` }
+				afterTimeout={ onSuccess }
+			/>
+		);
 	}
 
 	return registerCeremonyActive ? (
@@ -134,39 +140,6 @@ function WaitingForSecurityKey() {
 
 			<p className="wporg-2fa__webauthn-register-key-status">
 				<Spinner />
-			</p>
-		</>
-	);
-}
-
-/**
- * Render the "Success" component.
- *
- * The user sees this once their security key has successfully been registered.
- *
- * @param props
- * @param props.newKeyName
- * @param props.afterTimeout
- */
-function Success( { newKeyName, afterTimeout } ) {
-	const [ hasTimer, setHasTimer ] = useState( false );
-
-	if ( ! hasTimer ) {
-		// Matches the length of the CSS animation property on .wporg-2fa__success
-		setTimeout( afterTimeout, 4000 );
-		setHasTimer( true );
-	}
-
-	return (
-		<>
-			<p className="wporg-2fa__screen-intro">
-				Success! Your { newKeyName } is successfully registered.
-			</p>
-
-			<p className="wporg-2fa__webauthn-register-key-status">
-				<div className="wporg-2fa__success">
-					<Icon icon={ check } />
-				</div>
 			</p>
 		</>
 	);

--- a/settings/src/components/webauthn/register-key.js
+++ b/settings/src/components/webauthn/register-key.js
@@ -152,8 +152,8 @@ function Success( { newKeyName, afterTimeout } ) {
 	const [ hasTimer, setHasTimer ] = useState( false );
 
 	if ( ! hasTimer ) {
-		// TODO need to sync this timing with the animation below
-		setTimeout( afterTimeout, 2000 );
+		// Matches the length of the CSS animation property on .wporg-2fa__success
+		setTimeout( afterTimeout, 4000 );
 		setHasTimer( true );
 	}
 
@@ -163,9 +163,10 @@ function Success( { newKeyName, afterTimeout } ) {
 				Success! Your { newKeyName } is successfully registered.
 			</p>
 
-			{ /* TODO replace w/ custom animation */ }
 			<p className="wporg-2fa__webauthn-register-key-status">
-				<Icon icon={ check } />
+				<div className="wporg-2fa__success">
+					<Icon icon={ check } />
+				</div>
 			</p>
 		</>
 	);

--- a/settings/src/components/webauthn/webauthn.js
+++ b/settings/src/components/webauthn/webauthn.js
@@ -35,6 +35,18 @@ export default function WebAuthn() {
 	const [ confirmingDisable, setConfirmingDisable ] = useState( false );
 
 	/**
+	 * Clear any notices then move to the desired step in the flow
+	 */
+	const updateFlow = useCallback(
+		( nextFlow ) => {
+			setGlobalNotice( '' );
+			setStatusError( '' );
+			setFlow( nextFlow );
+		},
+		[ setGlobalNotice ]
+	);
+
+	/**
 	 * Enable the WebAuthn provider.
 	 */
 	const toggleProvider = useCallback( async () => {
@@ -71,8 +83,8 @@ export default function WebAuthn() {
 			await toggleProvider();
 		}
 
-		setFlow( 'manage' );
-	}, [ webAuthnEnabled, toggleProvider ] );
+		updateFlow( 'manage' );
+	}, [ webAuthnEnabled, toggleProvider, updateFlow ] );
 
 	/**
 	 * Display the modal to confirm disabling the WebAuthn provider.
@@ -90,7 +102,10 @@ export default function WebAuthn() {
 
 	if ( 'register' === flow ) {
 		return (
-			<RegisterKey onSuccess={ onRegisterSuccess } onCancel={ () => setFlow( 'manage' ) } />
+			<RegisterKey
+				onSuccess={ onRegisterSuccess }
+				onCancel={ () => updateFlow( 'manage' ) }
+			/>
 		);
 	}
 
@@ -106,7 +121,7 @@ export default function WebAuthn() {
 			{ keys.length > 0 && <ListKeys /> }
 
 			<p className="wporg-2fa__submit-actions">
-				<Button variant="primary" onClick={ () => setFlow( 'register' ) }>
+				<Button variant="primary" onClick={ () => updateFlow( 'register' ) }>
 					Register new key
 				</Button>
 

--- a/settings/src/style.scss
+++ b/settings/src/style.scss
@@ -56,6 +56,35 @@ $alert-blue: #72aee6;
 	}
 }
 
+@keyframes success {
+	0% {
+		transform: scale(0);
+	}
+	10% {
+		transform: scale(1.5);
+	}
+	20% {
+		transform: scale(1);
+	}
+	80% {
+		transform: scale(1);
+	}
+	100% {
+		transform: scale(0);
+	}
+}
+
+.wporg-2fa__success {
+	transform: scale(0);
+	background: #33F078;
+	border-radius: 50%;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding: 10px;
+	animation: success 4s ease-in-out;
+}
+
 .wporg-2fa__token {
 	letter-spacing: .3em;
 }

--- a/settings/src/style.scss
+++ b/settings/src/style.scss
@@ -56,35 +56,6 @@ $alert-blue: #72aee6;
 	}
 }
 
-@keyframes success {
-	0% {
-		transform: scale(0);
-	}
-	10% {
-		transform: scale(1.5);
-	}
-	20% {
-		transform: scale(1);
-	}
-	80% {
-		transform: scale(1);
-	}
-	100% {
-		transform: scale(0);
-	}
-}
-
-.wporg-2fa__success {
-	transform: scale(0);
-	background: #33F078;
-	border-radius: 50%;
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	padding: 10px;
-	animation: success 4s ease-in-out;
-}
-
 .wporg-2fa__token {
 	letter-spacing: .3em;
 }
@@ -120,3 +91,4 @@ $alert-blue: #72aee6;
 @import "components/screen-navigation";
 @import "components/auto-tabbing-input";
 @import "components/revalidate-modal";
+@import "components/success";


### PR DESCRIPTION
Closes #226 

- Clears notices from other actions in WebAuthn UI
- Adds a success animation after a key is registered or TOTP is enabled, see issue for specs and [comment](https://github.com/WordPress/wporg-two-factor/issues/194#issuecomment-1672772958) regarding using the animation in places other than WebAuthn.

![webauthn success](https://github.com/WordPress/wporg-two-factor/assets/1017872/3e5602b7-2816-423b-845c-9b2cae7d55d4)

![totp success](https://github.com/WordPress/wporg-two-factor/assets/1017872/8afba68d-c36d-4f56-a434-dc77d58ac156)

## Testing

Checkout this branch in your sandbox.

WebAuthn still has a development only flag, so either do a dev build of `settings` with `NODE_ENV=development wp-scripts build --webpack-copy-php`, or a prod build and remove the [dev flag](https://github.com/WordPress/wporg-two-factor/blob/trunk/settings/src/components/account-status.js#L60).

For TOTP, disable if enabled, then re-enable. You should see the success message and animation after entering the 6 digit code to enable your app.

For WebAuthn, register a new key and you should see the success message and animation when the key has been successfully added.

You should also test deleting a key so that the delete success notice is displayed. When you enter the register key flow, that notice should be dismissed.