### PR TITLE
Prevent block from being inserted in Editor

### DIFF
--- a/settings/src/block.json
+++ b/settings/src/block.json
@@ -7,7 +7,8 @@
 	"category": "widgets",
 	"icon": "lock",
 	"supports": {
-		"html": false
+		"html": false,
+		"inserter": false
 	},
 	"attributes": {
 		"userId": {

--- a/settings/src/index.js
+++ b/settings/src/index.js
@@ -13,6 +13,3 @@ import './style.scss';
 registerBlockType( metadata.name, {
 	edit: Edit,
 } );
-// todo prevent block from being inserted in editor
-// or maybe don't make it a block at all?
-// really just using this to get the react tooling setup quickly. there might be a better way


### PR DESCRIPTION
This cleans up an old `@todo` comment