### PR TITLE
Update animations and modals

### DIFF
--- a/settings/src/components/account-status.scss
+++ b/settings/src/components/account-status.scss
@@ -35,6 +35,7 @@
 			.wporg-2fa__status-icon {
 				grid-area: status;
 				align-self: center;
+				margin: 0;
 			}
 
 			h3 {

--- a/settings/src/components/account-status.scss
+++ b/settings/src/components/account-status.scss
@@ -35,7 +35,6 @@
 			.wporg-2fa__status-icon {
 				grid-area: status;
 				align-self: center;
-				margin: 0;
 			}
 
 			h3 {

--- a/settings/src/components/success.js
+++ b/settings/src/components/success.js
@@ -18,19 +18,19 @@ export default function Success( { message, afterTimeout } ) {
 
 	if ( ! hasTimer ) {
 		// Time matches the length of the CSS animation property on .wporg-2fa__success
-		setTimeout( afterTimeout, 4000 );
+		setTimeout( afterTimeout, 5000 );
 		setHasTimer( true );
 	}
 
 	return (
-		<>
-			<p className="wporg-2fa__screen-intro">{ message }</p>
+		<div className="wporg-2fa__success">
+			<p>{ message }</p>
 
-			<p className="wporg-2fa__webauthn-register-key-status" aria-hidden>
-				<div className="wporg-2fa__success">
+			<div className="wporg-2fa__status-icon" aria-hidden>
+				<div className="wporg-2fa__success-animation">
 					<Icon icon={ check } />
 				</div>
-			</p>
-		</>
+			</div>
+		</div>
 	);
 }

--- a/settings/src/components/success.js
+++ b/settings/src/components/success.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { Flex } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { Icon, check } from '@wordpress/icons';
 
@@ -23,7 +24,7 @@ export default function Success( { message, afterTimeout } ) {
 	}
 
 	return (
-		<div className="wporg-2fa__success">
+		<Flex className="wporg-2fa__success" direction="column">
 			<p>{ message }</p>
 
 			<div className="wporg-2fa__status-icon" aria-hidden>
@@ -31,6 +32,6 @@ export default function Success( { message, afterTimeout } ) {
 					<Icon icon={ check } />
 				</div>
 			</div>
-		</div>
+		</Flex>
 	);
 }

--- a/settings/src/components/success.js
+++ b/settings/src/components/success.js
@@ -27,7 +27,7 @@ export default function Success( { message, afterTimeout } ) {
 		<Flex className="wporg-2fa__success" direction="column">
 			<p>{ message }</p>
 
-			<div className="wporg-2fa__status-icon" aria-hidden>
+			<div className="wporg-2fa__process-status" aria-hidden>
 				<div className="wporg-2fa__success-animation">
 					<Icon icon={ check } />
 				</div>

--- a/settings/src/components/success.scss
+++ b/settings/src/components/success.scss
@@ -1,9 +1,5 @@
 .wporg-2fa__success {
 	flex: 1;
-
-	.wporg-2fa__status-icon {
-		flex: 1;
-	}
 }
 
 @keyframes success {

--- a/settings/src/components/success.scss
+++ b/settings/src/components/success.scss
@@ -1,7 +1,5 @@
 .wporg-2fa__success {
 	flex: 1;
-	display: flex;
-	flex-direction: column;
 
 	.wporg-2fa__status-icon {
 		flex: 1;
@@ -10,6 +8,9 @@
 
 @keyframes success {
 	0% {
+		transform: scale(0);
+	}
+	10% {
 		transform: scale(0);
 	}
 	20% {

--- a/settings/src/components/success.scss
+++ b/settings/src/components/success.scss
@@ -1,11 +1,21 @@
+.wporg-2fa__success {
+	flex: 1;
+	display: flex;
+	flex-direction: column;
+
+	.wporg-2fa__status-icon {
+		flex: 1;
+	}
+}
+
 @keyframes success {
 	0% {
 		transform: scale(0);
 	}
-	10% {
+	20% {
 		transform: scale(1.5);
 	}
-	20% {
+	30% {
 		transform: scale(1);
 	}
 	80% {
@@ -16,7 +26,7 @@
 	}
 }
 
-.wporg-2fa__success {
+.wporg-2fa__success-animation {
 	transform: scale(0);
 	background: #33F078;
 	border-radius: 50%;
@@ -25,5 +35,5 @@
 	justify-content: center;
 	width: 32px;
 	height: 32px;
-	animation: success 4s ease-in-out;
+	animation: success 5s ease-in-out;
 }

--- a/settings/src/components/totp.js
+++ b/settings/src/components/totp.js
@@ -29,10 +29,12 @@ export default function TOTP() {
 
 	if ( success ) {
 		return (
-			<Success
-				message="Success! Your two-factor authentication app is set up."
-				afterTimeout={ afterTimeout }
-			/>
+			<div className="wporg-2fa__totp_success">
+				<Success
+					message="Success! Your two-factor authentication app is set up."
+					afterTimeout={ afterTimeout }
+				/>
+			</div>
 		);
 	}
 

--- a/settings/src/components/totp.js
+++ b/settings/src/components/totp.js
@@ -341,14 +341,14 @@ function Manage() {
 	const [ confirmingDisable, setConfirmingDisable ] = useState( false );
 
 	/**
-	 * Display the modal to confirm disabling the WebAuthn provider.
+	 * Display the confirmation modal for disabling the TOTP provider.
 	 */
 	const showConfirmDisableModal = useCallback( () => {
 		setConfirmingDisable( true );
 	}, [] );
 
 	/**
-	 * Hide te modal to confirm disabling the WebAuthn provider.
+	 * Remove the confirmation modal for disabling the TOTP provider.
 	 */
 	const hideConfirmDisableModal = useCallback( () => {
 		setConfirmingDisable( false );

--- a/settings/src/components/totp.js
+++ b/settings/src/components/totp.js
@@ -29,12 +29,12 @@ export default function TOTP() {
 
 	if ( success ) {
 		return (
-			<div className="wporg-2fa__totp_success">
+			<Flex className="wporg-2fa__totp_success" direction="column">
 				<Success
 					message="Success! Your two-factor authentication app is set up."
 					afterTimeout={ afterTimeout }
 				/>
-			</div>
+			</Flex>
 		);
 	}
 

--- a/settings/src/components/totp.scss
+++ b/settings/src/components/totp.scss
@@ -1,12 +1,13 @@
 .wporg-2fa__totp {
+	$min-container-height: 590px;
+
 	.wporg-2fa__totp_success {
-		display: flex;
-		min-height: 620px;
-		flex-direction: column;
+		min-height: $min-container-height;
 	}
 
 	.wporg-2fa__totp_setup-container {
 		position: relative;
+		min-height: $min-container-height;
 
 		> .components-button {
 			position: absolute;

--- a/settings/src/components/totp.scss
+++ b/settings/src/components/totp.scss
@@ -1,4 +1,10 @@
 .wporg-2fa__totp {
+	.wporg-2fa__totp_success {
+		display: flex;
+		min-height: 620px;
+		flex-direction: column;
+	}
+
 	.wporg-2fa__totp_setup-container {
 		position: relative;
 

--- a/settings/src/components/webauthn/list-keys.js
+++ b/settings/src/components/webauthn/list-keys.js
@@ -114,9 +114,9 @@ function ConfirmRemoveKey( { keyToRemove, onConfirm, onClose, deleting, error } 
 			</div>
 
 			{ deleting && (
-				<p className="wporg-2fa__webauthn-register-key-status">
+				<div className="wporg-2fa__status-icon">
 					<Spinner />
-				</p>
+				</div>
 			) }
 
 			{ error && (

--- a/settings/src/components/webauthn/list-keys.js
+++ b/settings/src/components/webauthn/list-keys.js
@@ -104,7 +104,7 @@ function ConfirmRemoveKey( { keyToRemove, onConfirm, onClose, deleting, error } 
 			</p>
 
 			{ deleting ? (
-				<div className="wporg-2fa__status-icon">
+				<div className="wporg-2fa__process-status">
 					<Spinner />
 				</div>
 			) : (

--- a/settings/src/components/webauthn/list-keys.js
+++ b/settings/src/components/webauthn/list-keys.js
@@ -103,19 +103,19 @@ function ConfirmRemoveKey( { keyToRemove, onConfirm, onClose, deleting, error } 
 				Are you sure you want to remove the <code>{ keyToRemove.name }</code> security key?
 			</p>
 
-			<div className="wporg-2fa__submit-actions">
-				<Button variant="primary" onClick={ onConfirm }>
-					Remove { keyToRemove.name }
-				</Button>
-
-				<Button variant="tertiary" onClick={ onClose }>
-					Cancel
-				</Button>
-			</div>
-
-			{ deleting && (
+			{ deleting ? (
 				<div className="wporg-2fa__status-icon">
 					<Spinner />
+				</div>
+			) : (
+				<div className="wporg-2fa__submit-actions">
+					<Button variant="primary" onClick={ onConfirm }>
+						Remove { keyToRemove.name }
+					</Button>
+
+					<Button variant="tertiary" onClick={ onClose }>
+						Cancel
+					</Button>
 				</div>
 			) }
 

--- a/settings/src/components/webauthn/register-key.js
+++ b/settings/src/components/webauthn/register-key.js
@@ -102,6 +102,7 @@ export default function RegisterKey( { onSuccess, onCancel } ) {
 				onChange={ ( name ) => setKeyName( name ) }
 				value={ keyName }
 				required
+				data-1p-ignore // Prevent 1Password from showing up
 			/>
 
 			<p className="wporg-2fa__submit-actions">

--- a/settings/src/components/webauthn/register-key.js
+++ b/settings/src/components/webauthn/register-key.js
@@ -89,7 +89,7 @@ export default function RegisterKey( { onSuccess, onCancel } ) {
 		<>
 			<p>Connecting...</p>
 
-			<div className="wporg-2fa__status-icon">
+			<div className="wporg-2fa__process-status">
 				<Spinner />
 			</div>
 		</>
@@ -137,7 +137,7 @@ function WaitingForSecurityKey() {
 		<>
 			<p>Waiting for security key. Connect and touch your security key to register it.</p>
 
-			<div className="wporg-2fa__status-icon">
+			<div className="wporg-2fa__process-status">
 				<Spinner />
 			</div>
 		</>

--- a/settings/src/components/webauthn/register-key.js
+++ b/settings/src/components/webauthn/register-key.js
@@ -28,7 +28,6 @@ export default function RegisterKey( { onSuccess, onCancel } ) {
 		user: { userRecord },
 	} = useContext( GlobalContext );
 	const record = userRecord.record;
-
 	const [ error, setError ] = useState( false );
 	const [ keyName, setKeyName ] = useState( '' );
 	const [ step, setStep ] = useState( 'input' );
@@ -88,10 +87,11 @@ export default function RegisterKey( { onSuccess, onCancel } ) {
 
 	return registerCeremonyActive ? (
 		<>
-			<p className="wporg-2fa__screen-intro">Connecting...</p>
-			<p className="wporg-2fa__webauthn-register-key-status">
+			<p>Connecting...</p>
+
+			<div className="wporg-2fa__status-icon">
 				<Spinner />
-			</p>
+			</div>
 		</>
 	) : (
 		<form onSubmit={ onRegister }>
@@ -134,13 +134,11 @@ export default function RegisterKey( { onSuccess, onCancel } ) {
 function WaitingForSecurityKey() {
 	return (
 		<>
-			<p className="wporg-2fa__screen-intro">
-				Waiting for security key. Connect and touch your security key to register it.
-			</p>
+			<p>Waiting for security key. Connect and touch your security key to register it.</p>
 
-			<p className="wporg-2fa__webauthn-register-key-status">
+			<div className="wporg-2fa__status-icon">
 				<Spinner />
-			</p>
+			</div>
 		</>
 	);
 }

--- a/settings/src/components/webauthn/webauthn.js
+++ b/settings/src/components/webauthn/webauthn.js
@@ -102,10 +102,12 @@ export default function WebAuthn() {
 
 	if ( 'register' === flow ) {
 		return (
-			<RegisterKey
-				onSuccess={ onRegisterSuccess }
-				onCancel={ () => updateFlow( 'manage' ) }
-			/>
+			<div className="wporg-2fa__webauthn-register">
+				<RegisterKey
+					onSuccess={ onRegisterSuccess }
+					onCancel={ () => updateFlow( 'manage' ) }
+				/>
+			</div>
 		);
 	}
 
@@ -137,9 +139,9 @@ export default function WebAuthn() {
 			</p>
 
 			{ statusWaiting && (
-				<p className="wporg-2fa__webauthn-register-key-status">
+				<div className="wporg-2fa__status-icon">
 					<Spinner />
-				</p>
+				</div>
 			) }
 
 			{ statusError && (
@@ -197,9 +199,9 @@ function ConfirmDisableKeys( { onConfirm, onClose, disabling, error } ) {
 			</div>
 
 			{ disabling && (
-				<p className="wporg-2fa__webauthn-register-key-status">
+				<div className="wporg-2fa__status-icon">
 					<Spinner />
-				</p>
+				</div>
 			) }
 		</Modal>
 	);

--- a/settings/src/components/webauthn/webauthn.js
+++ b/settings/src/components/webauthn/webauthn.js
@@ -43,7 +43,21 @@ export default function WebAuthn() {
 	);
 
 	/**
-	 * Enable the WebAuthn provider.
+	 * Display the modal to confirm disabling the WebAuthn provider.
+	 */
+	const showConfirmDisableModal = useCallback( () => {
+		setConfirmingDisable( true );
+	}, [] );
+
+	/**
+	 * Hide te modal to confirm disabling the WebAuthn provider.
+	 */
+	const hideConfirmDisableModal = useCallback( () => {
+		setConfirmingDisable( false );
+	}, [] );
+
+	/**
+	 * Toggle enablement of the WebAuthn provider.
 	 */
 	const toggleProvider = useCallback( async () => {
 		const newStatus = webAuthnEnabled ? 'disable' : 'enable';
@@ -65,11 +79,12 @@ export default function WebAuthn() {
 			await refreshRecord( userRecord );
 			setGlobalNotice( `Successfully ${ newStatus }d Security Keys.` );
 		} catch ( error ) {
+			hideConfirmDisableModal();
 			setStatusError( error?.message || error?.responseJSON?.data || error );
 		} finally {
 			setStatusWaiting( false );
 		}
-	}, [ userId, setGlobalNotice, userRecord, webAuthnEnabled ] );
+	}, [ webAuthnEnabled, userId, userRecord, setGlobalNotice, hideConfirmDisableModal ] );
 
 	/**
 	 * Handle post-registration processing.
@@ -81,20 +96,6 @@ export default function WebAuthn() {
 
 		updateFlow( 'manage' );
 	}, [ webAuthnEnabled, toggleProvider, updateFlow ] );
-
-	/**
-	 * Display the modal to confirm disabling the WebAuthn provider.
-	 */
-	const showConfirmDisableModal = useCallback( () => {
-		setConfirmingDisable( true );
-	}, [] );
-
-	/**
-	 * Hide te modal to confirm disabling the WebAuthn provider.
-	 */
-	const hideConfirmDisableModal = useCallback( () => {
-		setConfirmingDisable( false );
-	}, [] );
 
 	if ( 'register' === flow ) {
 		return (
@@ -165,15 +166,9 @@ export default function WebAuthn() {
  * @param {Object}   props
  * @param {Function} props.onConfirm
  * @param {Function} props.onClose
- * @param {string}   props.error
  * @param {boolean}  props.disabling
  */
-function ConfirmDisableKeys( { onConfirm, onClose, disabling, error } ) {
-	if ( !! error ) {
-		onClose();
-		return null;
-	}
-
+function ConfirmDisableKeys( { onConfirm, onClose, disabling } ) {
 	return (
 		<Modal
 			title={ `Disable security keys` }

--- a/settings/src/components/webauthn/webauthn.js
+++ b/settings/src/components/webauthn/webauthn.js
@@ -43,14 +43,14 @@ export default function WebAuthn() {
 	);
 
 	/**
-	 * Display the modal to confirm disabling the WebAuthn provider.
+	 * Display the confirmation modal for disabling the WebAuthn provider.
 	 */
 	const showConfirmDisableModal = useCallback( () => {
 		setConfirmingDisable( true );
 	}, [] );
 
 	/**
-	 * Hide te modal to confirm disabling the WebAuthn provider.
+	 * Remove the confirmation modal for disabling the WebAuthn provider.
 	 */
 	const hideConfirmDisableModal = useCallback( () => {
 		setConfirmingDisable( false );

--- a/settings/src/components/webauthn/webauthn.js
+++ b/settings/src/components/webauthn/webauthn.js
@@ -19,16 +19,12 @@ import RegisterKey from './register-key';
  */
 export default function WebAuthn() {
 	const {
-		user: {
-			userRecord,
-			userRecord: {
-				record: { id: userId },
-			},
-			webAuthnEnabled,
-		},
+		user: { userRecord, webAuthnEnabled },
 		setGlobalNotice,
 	} = useContext( GlobalContext );
-	const keys = userRecord.record[ '2fa_webauthn_keys' ];
+	const {
+		record: { id: userId, '2fa_webauthn_keys': keys },
+	} = userRecord;
 	const [ flow, setFlow ] = useState( 'manage' );
 	const [ statusError, setStatusError ] = useState( '' );
 	const [ statusWaiting, setStatusWaiting ] = useState( false );

--- a/settings/src/components/webauthn/webauthn.js
+++ b/settings/src/components/webauthn/webauthn.js
@@ -188,19 +188,19 @@ function ConfirmDisableKeys( { onConfirm, onClose, disabling, error } ) {
 				Are you sure you want to disable security keys?
 			</p>
 
-			<div className="wporg-2fa__submit-actions">
-				<Button variant="primary" onClick={ onConfirm }>
-					Disable
-				</Button>
-
-				<Button variant="tertiary" onClick={ onClose }>
-					Cancel
-				</Button>
-			</div>
-
-			{ disabling && (
+			{ disabling ? (
 				<div className="wporg-2fa__status-icon">
 					<Spinner />
+				</div>
+			) : (
+				<div className="wporg-2fa__submit-actions">
+					<Button variant="primary" onClick={ onConfirm }>
+						Disable
+					</Button>
+
+					<Button variant="tertiary" onClick={ onClose }>
+						Cancel
+					</Button>
 				</div>
 			) }
 		</Modal>

--- a/settings/src/components/webauthn/webauthn.js
+++ b/settings/src/components/webauthn/webauthn.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { Button, Notice, Spinner, Modal } from '@wordpress/components';
+import { Button, Flex, Notice, Spinner, Modal } from '@wordpress/components';
 import { useCallback, useContext, useState } from '@wordpress/element';
 import { Icon, cancelCircleFilled } from '@wordpress/icons';
 import apiFetch from '@wordpress/api-fetch';
@@ -102,12 +102,12 @@ export default function WebAuthn() {
 
 	if ( 'register' === flow ) {
 		return (
-			<div className="wporg-2fa__webauthn-register">
+			<Flex className="wporg-2fa__webauthn-register" direction="column">
 				<RegisterKey
 					onSuccess={ onRegisterSuccess }
 					onCancel={ () => updateFlow( 'manage' ) }
 				/>
-			</div>
+			</Flex>
 		);
 	}
 
@@ -139,7 +139,7 @@ export default function WebAuthn() {
 			</p>
 
 			{ statusWaiting && (
-				<div className="wporg-2fa__status-icon">
+				<div className="wporg-2fa__process-status">
 					<Spinner />
 				</div>
 			) }
@@ -189,7 +189,7 @@ function ConfirmDisableKeys( { onConfirm, onClose, disabling, error } ) {
 			</p>
 
 			{ disabling ? (
-				<div className="wporg-2fa__status-icon">
+				<div className="wporg-2fa__process-status">
 					<Spinner />
 				</div>
 			) : (

--- a/settings/src/components/webauthn/webauthn.scss
+++ b/settings/src/components/webauthn/webauthn.scss
@@ -22,9 +22,7 @@
 	}
 
 	.wporg-2fa__webauthn-register {
-		display: flex;
 		min-height: 300px;
-		flex-direction: column;
 	}
 }
 

--- a/settings/src/components/webauthn/webauthn.scss
+++ b/settings/src/components/webauthn/webauthn.scss
@@ -20,21 +20,16 @@
 			font-size: 13px;
 		}
 	}
+
+	.wporg-2fa__webauthn-register {
+		display: flex;
+		min-height: 300px;
+		flex-direction: column;
+	}
 }
 
 .components-modal__frame.wporg-2fa__confirm-delete-key {
 	.components-notice.is-error {
 		margin-top: 18px;
-	}
-}
-
-.wporg-2fa__webauthn-register-key-status {
-	display: flex;
-	justify-content: center;
-	align-items: center;
-	margin: 40px 0;
-
-	svg.components-spinner {
-		overflow: visible;
 	}
 }

--- a/settings/src/style.scss
+++ b/settings/src/style.scss
@@ -60,7 +60,7 @@ $alert-blue: #72aee6;
 	letter-spacing: .3em;
 }
 
-.wporg-2fa__status-icon {
+.wporg-2fa__process-status {
 	flex: 1;
 	display: flex;
 	justify-content: center;

--- a/settings/src/style.scss
+++ b/settings/src/style.scss
@@ -67,6 +67,11 @@ $alert-blue: #72aee6;
 	align-items: center;
 	margin: 40px 0;
 
+	.components-modal__content & {
+		height: 36px; // Matches the button height
+		margin-bottom: 0;
+	}
+
 	svg.components-spinner {
 		overflow: visible;
 	}

--- a/settings/src/style.scss
+++ b/settings/src/style.scss
@@ -60,6 +60,18 @@ $alert-blue: #72aee6;
 	letter-spacing: .3em;
 }
 
+.wporg-2fa__status-icon {
+	flex: 1;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	margin: 40px 0;
+
+	svg.components-spinner {
+		overflow: visible;
+	}
+}
+
 .components-notice {
 	margin-left: 0;
 	margin-right: 0;

--- a/settings/src/style.scss
+++ b/settings/src/style.scss
@@ -65,12 +65,7 @@ $alert-blue: #72aee6;
 	display: flex;
 	justify-content: center;
 	align-items: center;
-	margin: 40px 0;
-
-	.components-modal__content & {
-		height: 36px; // Matches the button height
-		margin-bottom: 0;
-	}
+	height: 36px; // Matches the button height
 
 	svg.components-spinner {
 		overflow: visible;


### PR DESCRIPTION
Closes #229, #225

- Adds a minimum height to the TOTP and Security Key success animations
- Adds a slight delay to the start of the success animation
- Hides the action buttons in the Security Key modals when actions are processing
- Adds a modal to confirm disabling TOTP, to be consistent with security keys actions (#225)

## Screenshots

### Enable and disable app

<img src="https://github.com/WordPress/wporg-two-factor/assets/1017872/24c10778-3ce7-4309-aef9-77ecd516db1b" width="600">

### Add and remove security key

<img src="https://github.com/WordPress/wporg-two-factor/assets/1017872/45e42d05-2338-4948-96ac-07abdb202c2e" width="600">

### Disable security keys

(Error is expected)

<img src="https://github.com/WordPress/wporg-two-factor/assets/1017872/5447390d-31fd-4455-b435-3cdc87ba3744" width="600">
