### PR TITLE
Update the screen variable ASAP.

### DIFF
--- a/settings/src/script.js
+++ b/settings/src/script.js
@@ -63,7 +63,7 @@ function Main( { userId } ) {
 	const [ error, setError ] = useState( '' );
 
 	let currentUrl = new URL( document.location.href );
-	let initialScreen = currentUrl.searchParams.get( 'screen' );
+	const initialScreen = currentUrl.searchParams.get( 'screen' );
 	const [ screen, setScreen ] = useState( initialScreen );
 
 	// The index is the URL slug and the value is the React component.
@@ -83,11 +83,8 @@ function Main( { userId } ) {
 	// The screens where a recent two factor challenge is required.
 	const twoFactorRequiredScreens = [ 'webauthn', 'totp', 'backup-codes' ];
 
-	if ( ! components[ initialScreen ] ) {
-		initialScreen = 'account-status';
-		setScreen( initialScreen );
-		currentUrl.searchParams.set( 'screen', initialScreen );
-		window.history.pushState( {}, '', currentUrl );
+	if ( ! components[ screen ] ) {
+		setScreen( 'account-status' );
 	}
 
 	// Listen for back/forward button clicks.
@@ -98,6 +95,11 @@ function Main( { userId } ) {
 			window.removeEventListener( 'popstate', handlePopState );
 		};
 	}, [] );
+
+	useEffect( () => {
+		currentUrl.searchParams.set( 'screen', screen );
+		window.history.pushState( {}, '', currentUrl );
+	}, [ screen ] );
 
 	// Trigger a re-render when the back/forward buttons are clicked.
 	const handlePopState = useCallback( () => {

--- a/settings/src/script.js
+++ b/settings/src/script.js
@@ -85,6 +85,7 @@ function Main( { userId } ) {
 
 	if ( ! components[ initialScreen ] ) {
 		initialScreen = 'account-status';
+		setScreen( initialScreen );
 		currentUrl.searchParams.set( 'screen', initialScreen );
 		window.history.pushState( {}, '', currentUrl );
 	}


### PR DESCRIPTION
Fixes #222 

This PR fixes a broken screen in production where users visits `https://wordpress.org/support/users/{username}/edit/account`. I was unable to reproduce this locally, so this does require a sandbox. My guess is that the local environment doesn't have as much latency as production and rendering happens more quickly. I have not verified that assumption.

## What's happening?
I've described the issue in [this comment](https://github.com/WordPress/wporg-two-factor/issues/222#issuecomment-1704458307). Essentially we have some default logic where we use the URL to determine the current screen on load. That doesn't work properly.

## Fix

We can fix it by using the `setScreen` function and setting the screen immediately. There are probably some refactors that would make this more predictable but this will work in the interim.

## How to test
1. Before applying this patch, reproduce issue:
   - Log into your wp account
   - Navigate to https://wordpress.org/support/users/{username}/edit/account/
     - Notice the error in your console
   -  Navigate to https://wordpress.org/support/users/{username}/edit/account/?screen=account-status
      - Notice it works
2. Copy your `settings/build/script.js` into your sandbox build folder
3. Navigate to https://wordpress.org/support/users/{username}/edit/account/
     - It should load properly

