### PR TITLE
Try moving security keys below the one time passwords via auth app.

### DIFF
--- a/settings/src/components/account-status.js
+++ b/settings/src/components/account-status.js
@@ -56,20 +56,17 @@ export default function AccountStatus() {
 				}
 			/>
 
-			{ /* TODO: Only enable WebAuthn UI in development, until it's finished. */ }
-			{ 'development' === process.env.NODE_ENV && (
-				<SettingStatusCard
-					screen="webauthn"
-					status={ hasPrimaryProvider && ! webAuthnEnabled ? 'info' : webAuthnEnabled }
-					headerText="Two-Factor Security Key"
-					bodyText={
-						webAuthnEnabled
-							? 'You have two-factor authentication enabled using security keys.'
-							: 'You have not enabled security keys for two-factor authentication.'
-					}
-					isPrimary={ 'TwoFactor_Provider_WebAuthn' === primaryProvider && totpEnabled }
-				/>
-			) }
+			<SettingStatusCard
+				screen="webauthn"
+				status={ hasPrimaryProvider && ! webAuthnEnabled ? 'info' : webAuthnEnabled }
+				headerText="Two-Factor Security Key"
+				bodyText={
+					webAuthnEnabled
+						? 'You have two-factor authentication enabled using security keys.'
+						: 'You have not enabled security keys for two-factor authentication.'
+				}
+				isPrimary={ 'TwoFactor_Provider_WebAuthn' === primaryProvider && totpEnabled }
+			/>
 
 			<SettingStatusCard
 				screen="totp"

--- a/settings/src/components/account-status.js
+++ b/settings/src/components/account-status.js
@@ -57,18 +57,6 @@ export default function AccountStatus() {
 			/>
 
 			<SettingStatusCard
-				screen="webauthn"
-				status={ hasPrimaryProvider && ! webAuthnEnabled ? 'info' : webAuthnEnabled }
-				headerText="Two-Factor Security Key"
-				bodyText={
-					webAuthnEnabled
-						? 'You have two-factor authentication enabled using security keys.'
-						: 'You have not enabled security keys for two-factor authentication.'
-				}
-				isPrimary={ 'TwoFactor_Provider_WebAuthn' === primaryProvider && totpEnabled }
-			/>
-
-			<SettingStatusCard
 				screen="totp"
 				status={ hasPrimaryProvider && ! totpEnabled ? 'info' : totpEnabled }
 				headerText="Two-Factor App"
@@ -78,6 +66,18 @@ export default function AccountStatus() {
 						: 'You have not enabled an app for two-factor authentication.'
 				}
 				isPrimary={ 'Two_Factor_Totp' === primaryProvider && webAuthnEnabled }
+			/>
+
+			<SettingStatusCard
+				screen="webauthn"
+				status={ hasPrimaryProvider && ! webAuthnEnabled ? 'info' : webAuthnEnabled }
+				headerText="Two-Factor Security Key"
+				bodyText={
+					webAuthnEnabled
+						? 'You have two-factor authentication enabled using security keys.'
+						: 'You have not enabled security keys for two-factor authentication.'
+				}
+				isPrimary={ 'TwoFactor_Provider_WebAuthn' === primaryProvider && totpEnabled }
 			/>
 
 			<SettingStatusCard

--- a/settings/src/script.js
+++ b/settings/src/script.js
@@ -73,12 +73,8 @@ function Main( { userId } ) {
 		password: <Password />,
 		totp: <TOTP />,
 		'backup-codes': <BackupCodes />,
+		webauthn: <WebAuthn />,
 	};
-
-	// TODO: Only enable WebAuthn UI in development, until it's finished.
-	if ( 'development' === process.env.NODE_ENV ) {
-		components.webauthn = <WebAuthn />;
-	}
 
 	// The screens where a recent two factor challenge is required.
 	const twoFactorRequiredScreens = [ 'webauthn', 'totp', 'backup-codes' ];


### PR DESCRIPTION
This PR builds on #235 and moves the WebAuthN component down below the TOTP control. I don't know if this is the best idea but I thought a PR would be a good place to discuss (maybe it was already discussed?).

## Why
- We don't have a clear path to configure things properly yet, so top to bottom is likely the most logical
- TOTP works from multiple devices and we probably want it configured as a backup plan for users.
  - Maybe this is a dated idea though. 

| Current | After |
| --- | --- |
| <img width="697" alt="Screenshot 2023-09-11 at 2 57 10 PM" src="https://github.com/WordPress/wporg-two-factor/assets/1657336/de128600-344e-49a5-b5b1-b0c858c9ed5f"> | <img width="703" alt="Screenshot 2023-09-11 at 2 57 26 PM" src="https://github.com/WordPress/wporg-two-factor/assets/1657336/78673af1-9853-4eed-9606-7527b4682eba">|

