### PR TITLE
Update Remove security key modal

### DIFF
--- a/settings/src/components/webauthn/list-keys.js
+++ b/settings/src/components/webauthn/list-keys.js
@@ -95,7 +95,7 @@ export default function ListKeys() {
 function ConfirmRemoveKey( { keyToRemove, onConfirm, onClose, deleting, error } ) {
 	return (
 		<Modal
-			title={ `Delete security key` }
+			title="Delete security key"
 			className="wporg-2fa__confirm-delete-key"
 			onRequestClose={ onClose }
 		>

--- a/settings/src/components/webauthn/list-keys.js
+++ b/settings/src/components/webauthn/list-keys.js
@@ -3,7 +3,7 @@
  */
 import { Button, Modal, Notice, Spinner } from '@wordpress/components';
 import { useCallback, useContext, useState } from '@wordpress/element';
-import { Icon, cancelCircleFilled, key } from '@wordpress/icons';
+import { Icon, cancelCircleFilled, key as keyIcon } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -102,7 +102,7 @@ function ConfirmRemoveKey( { keyToRemove, onConfirm, onClose, deleting, error } 
 			<p className="wporg-2fa__screen-intro">
 				Are you sure you want to delete the following key?
 				<span className="wporg-2fa__screen-key">
-					<Icon icon={ key } />
+					<Icon icon={ keyIcon } />
 					<span>{ keyToRemove.name }</span>
 				</span>
 			</p>

--- a/settings/src/components/webauthn/list-keys.js
+++ b/settings/src/components/webauthn/list-keys.js
@@ -95,12 +95,15 @@ export default function ListKeys() {
 function ConfirmRemoveKey( { keyToRemove, onConfirm, onClose, deleting, error } ) {
 	return (
 		<Modal
-			title={ `Remove ${ keyToRemove.name }?` }
+			title={ `Delete security key` }
 			className="wporg-2fa__confirm-delete-key"
 			onRequestClose={ onClose }
 		>
 			<p className="wporg-2fa__screen-intro">
-				Are you sure you want to remove the <code>{ keyToRemove.name }</code> security key?
+				Are you sure you want to delete the following key?
+				<ul className="wporg-2fa__screen-list">
+					<li>{ keyToRemove.name }</li>
+				</ul>
 			</p>
 
 			{ deleting ? (
@@ -110,7 +113,7 @@ function ConfirmRemoveKey( { keyToRemove, onConfirm, onClose, deleting, error } 
 			) : (
 				<div className="wporg-2fa__submit-actions">
 					<Button variant="primary" isDestructive onClick={ onConfirm }>
-						Remove
+						Delete
 					</Button>
 
 					<Button variant="tertiary" onClick={ onClose }>

--- a/settings/src/components/webauthn/list-keys.js
+++ b/settings/src/components/webauthn/list-keys.js
@@ -109,8 +109,8 @@ function ConfirmRemoveKey( { keyToRemove, onConfirm, onClose, deleting, error } 
 				</div>
 			) : (
 				<div className="wporg-2fa__submit-actions">
-					<Button variant="primary" onClick={ onConfirm }>
-						Remove { keyToRemove.name }
+					<Button variant="primary" isDestructive onClick={ onConfirm }>
+						Remove
 					</Button>
 
 					<Button variant="tertiary" onClick={ onClose }>

--- a/settings/src/components/webauthn/list-keys.js
+++ b/settings/src/components/webauthn/list-keys.js
@@ -3,7 +3,7 @@
  */
 import { Button, Modal, Notice, Spinner } from '@wordpress/components';
 import { useCallback, useContext, useState } from '@wordpress/element';
-import { Icon, cancelCircleFilled } from '@wordpress/icons';
+import { Icon, cancelCircleFilled, key } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -101,9 +101,10 @@ function ConfirmRemoveKey( { keyToRemove, onConfirm, onClose, deleting, error } 
 		>
 			<p className="wporg-2fa__screen-intro">
 				Are you sure you want to delete the following key?
-				<ul className="wporg-2fa__screen-list">
-					<li>{ keyToRemove.name }</li>
-				</ul>
+				<span className="wporg-2fa__screen-key">
+					<Icon icon={ key } />
+					<span>{ keyToRemove.name }</span>
+				</span>
 			</p>
 
 			{ deleting ? (

--- a/settings/src/style.scss
+++ b/settings/src/style.scss
@@ -45,6 +45,7 @@ $alert-blue: #72aee6;
 	align-items: center;
 	margin: 8px 0 0;
 	gap: 4px;
+	font-weight: 600;
 }
 
 .wporg-2fa__screen-intro {

--- a/settings/src/style.scss
+++ b/settings/src/style.scss
@@ -40,6 +40,14 @@ $alert-blue: #72aee6;
 	}
 }
 
+.wporg-2fa__screen-list {
+	margin: 16px 0 0 16px;
+
+	li {
+		list-style-type: disc;
+	}
+}
+
 .wporg-2fa__screen-intro {
 	margin-bottom: 40px;
 }

--- a/settings/src/style.scss
+++ b/settings/src/style.scss
@@ -40,12 +40,11 @@ $alert-blue: #72aee6;
 	}
 }
 
-.wporg-2fa__screen-list {
-	margin: 16px 0 0 16px;
-
-	li {
-		list-style-type: disc;
-	}
+.wporg-2fa__screen-key {
+	display: flex;
+	align-items: center;
+	margin: 8px 0 0;
+	gap: 4px;
 }
 
 .wporg-2fa__screen-intro {


### PR DESCRIPTION
The delete key modal currently widens significantly based on the name of the key. It also is too verbose as we mention the key name in the title, content and remove button. Lastly, the originating interface uses "delete" language but the modal uses remove. 

**Changes:**
- Remove the key name from title and button
  - Since we no longer have the key name in the button, adds `isDestructive` to make it red
- Changes "Remove" wording to "Delete" to make it align with the underlying language.

| Before | After |
|--------|--------|
| <img width="673" alt="Screenshot 2023-09-12 at 9 57 43 AM" src="https://github.com/WordPress/wporg-two-factor/assets/1657336/40f8f0d0-559d-4ae3-a9bc-d7feb7184906"> | <img width="375" alt="Screenshot 2023-09-12 at 9 54 48 AM" src="https://github.com/WordPress/wporg-two-factor/assets/1657336/43dedbd2-2e16-47a2-8667-66f14e4857c0"> | 