### PR TITLE
Fix styles to match designs

### DIFF
--- a/settings/src/components/account-status.js
+++ b/settings/src/components/account-status.js
@@ -138,7 +138,7 @@ function SettingStatusCard( {
 	}
 
 	return (
-		<Card className={ classes } >
+		<Card className={ classes }>
 			{ disabled ? cardContent : <ScreenLink screen={ screen } anchorText={ cardContent } /> }
 		</Card>
 	);

--- a/settings/src/components/account-status.js
+++ b/settings/src/components/account-status.js
@@ -138,7 +138,7 @@ function SettingStatusCard( {
 	}
 
 	return (
-		<Card className={ classes }>
+		<Card className={ classes } >
 			{ disabled ? cardContent : <ScreenLink screen={ screen } anchorText={ cardContent } /> }
 		</Card>
 	);
@@ -174,5 +174,5 @@ function StatusIcon( { status } ) {
 			icon = cancelCircleFilled;
 	}
 
-	return <Icon icon={ icon } size={ 32 } className={ 'wporg-2fa__status-icon is-' + status } />;
+	return <Icon icon={ icon } size={ 24 } className={ 'wporg-2fa__status-icon is-' + status } />;
 }

--- a/settings/src/components/account-status.scss
+++ b/settings/src/components/account-status.scss
@@ -29,8 +29,8 @@
 				"status header      primary open"
 				"status description primary open"
 			;
-			grid-column-gap: 10px;
-			padding: 18px 14px;
+			grid-column-gap: 18px;
+			padding: 18px;
 
 			.wporg-2fa__status-icon {
 				grid-area: status;
@@ -41,8 +41,9 @@
 				grid-area: header;
 				align-self: end;
 				margin: 0;
-				font-size: 1.1em;
+				font-size: 1em;
 				color: $gray-900;
+				font-weight: 600;
 			}
 
 			.wporg-2fa__status-card-body {
@@ -73,7 +74,7 @@
 	.wporg-2fa__status-icon {
 		&.is-enabled,
 		&.is-ok {
-			fill: $alert-green;
+			fill: $black;
 		}
 
 		&.is-pending {

--- a/settings/src/components/screen-navigation.scss
+++ b/settings/src/components/screen-navigation.scss
@@ -20,7 +20,6 @@
 		font-weight: 600;
 		margin: unset;
 		text-transform: capitalize;
-		
 	}
 
 }

--- a/settings/src/components/screen-navigation.scss
+++ b/settings/src/components/screen-navigation.scss
@@ -1,7 +1,9 @@
 .wporg-2fa__navigation {
-	padding: 24px 0 !important; /* Override Gutenberg auto-generated. */
+	padding: 24px 0 16px !important; /* Override Gutenberg auto-generated. */
+	border-bottom: 0 !important;
 	justify-content: center !important;
 	position: relative;
+
 
 	a {
 		display: flex;
@@ -15,8 +17,10 @@
 	}
 
 	h3 {
+		font-weight: 600;
 		margin: unset;
 		text-transform: capitalize;
+		
 	}
 
 }

--- a/settings/src/style.scss
+++ b/settings/src/style.scss
@@ -19,6 +19,7 @@ $alert-blue: #72aee6;
 
 .wp-block-wporg-two-factor-settings {
 	position: relative;
+	font-size: 13px;
 
 	h3,
 	h4 {

--- a/settings/src/style.scss
+++ b/settings/src/style.scss
@@ -38,6 +38,10 @@ $alert-blue: #72aee6;
 			font-family: "Open Sans", sans-serif;
 		}
 	}
+
+	.components-card__body p:first-child {
+		margin-top: 0;
+	}
 }
 
 .wporg-2fa__screen-intro {


### PR DESCRIPTION
This PR updates some spacing, font-size and colors to align it more closely with the [figma](https://www.figma.com/file/6KPZbXujMGDRWWDR5odjDE/WP.org-improvements-%2F-QA?type=design&node-id=139-2569&mode=design&t=G02GLfhtodpGATsC-0) designs.
 
## Account Status
| Design | Before | After |
|--------|--------|--------|
| <img width="800" alt="Screenshot 2023-09-12 at 11 00 42 AM" src="https://github.com/WordPress/wporg-two-factor/assets/1657336/869d5ea6-c4bf-4eef-8bc6-b4f6adbc4ab0"> | <img width="768" alt="Screenshot 2023-09-12 at 10 52 44 AM" src="https://github.com/WordPress/wporg-two-factor/assets/1657336/7194d59f-342a-4cc6-9972-d25922d75eda"> | <img width="774" alt="Screenshot 2023-09-12 at 10 52 23 AM" src="https://github.com/WordPress/wporg-two-factor/assets/1657336/3c64b994-dd84-4065-b4c7-cef62e8e13e1"> |

## Specific view
| Design | Before | After |
|--------|--------|--------|
| <img width="318" alt="Screenshot 2023-09-12 at 10 56 48 AM" src="https://github.com/WordPress/wporg-two-factor/assets/1657336/c075d6e4-9bbd-4472-88eb-e8892c767302"> | <img width="779" alt="Screenshot 2023-09-12 at 10 51 31 AM" src="https://github.com/WordPress/wporg-two-factor/assets/1657336/f27f90b7-e3c5-4e27-86fe-d2032f252d05"> |  <img width="779" alt="Screenshot 2023-09-12 at 10 52 03 AM" src="https://github.com/WordPress/wporg-two-factor/assets/1657336/9cac266c-89ae-4d80-8c45-834593695329"> |



