### PR TITLE
 Show error message when server rejects new password

### DIFF
--- a/settings/src/components/password.js
+++ b/settings/src/components/password.js
@@ -47,7 +47,7 @@ export default function Password() {
 		}
 
 		setGlobalNotice( '' );
-	}, [ hasEdits ] );
+	}, [ hasEdits, setGlobalNotice ] );
 
 	/**
 	 * Handle clicking the `Generate Password` button.
@@ -55,7 +55,7 @@ export default function Password() {
 	const handlePasswordGenerate = useCallback( async () => {
 		edit( { password: generatePassword( 24, true, true ) } );
 		setInputType( 'text' );
-	}, [] );
+	}, [ edit ] );
 
 	// Handle form submission.
 	const handleFormSubmit = useCallback(
@@ -80,10 +80,10 @@ export default function Password() {
 
 			setGlobalNotice( 'New password saved.' );
 		},
-		[ passwordStrong, isSaving ]
+		[ passwordStrong, isSaving, save, setGlobalNotice ]
 	);
 
-	const handlePasswordChange = useCallback( ( password ) => edit( { password } ), [] );
+	const handlePasswordChange = useCallback( ( password ) => edit( { password } ), [ edit ] );
 
 	const handlePasswordToggle = useCallback(
 		() => setInputType( inputType === 'password' ? 'text' : 'password' ),


### PR DESCRIPTION
Fixes #53 

<img width="790" alt="Screenshot 2023-09-13 at 9 40 14 AM" src="https://github.com/WordPress/wporg-two-factor/assets/484068/642cc0b9-fbfc-4ba3-90ba-b7aef54e2fef">

### Testing

Add something like this to an mu-plugin, then try to save a new pw.

```php
function validate_rest_password( $result, WP_REST_Server $server, WP_REST_Request $request ) {
	if ( is_wp_error( $result ) ) {
		return $result;
	}

	if ( ! str_starts_with( $request->get_route(), '/wp/v2/users' ) ) {
		return $result;
	}

	if ( false === stripos( WP_REST_SERVER::EDITABLE, $request->get_method() ) ) {
		return $result;
	}

	$params = $request->get_params();

	if ( ! isset( $params['id'], $params['password'] ) ) {
		return $result;
	}

	$user = get_user_by( 'id', $params['id'] );

	if ( ! $user ) {
		return $request;
	}

	$result = new WP_Error( 'rest_password_weak', __( 'Password is too weak.' ), array( 'status' => 400 ) );

	return $result;
}
add_filter( 'rest_pre_dispatch', __NAMESPACE__ . '\validate_rest_password', 1, 3 );
```

### Misc

I also added some missing hook dependencies that eslint was complaining about. The commits are atomic, so you can review that separately if you want.