### PR TITLE
Prevent unintentional backup code regeneration

### DIFF
--- a/settings/src/components/backup-codes.js
+++ b/settings/src/components/backup-codes.js
@@ -181,11 +181,8 @@ function CodeList( { codes } ) {
  */
 function Manage( { setRegenerating } ) {
 	const {
-		user: {
-			userRecord: { record },
-		},
+		user: { backupCodesRemaining },
 	} = useContext( GlobalContext );
-	const remaining = record[ '2fa_backup_codes_remaining' ];
 
 	return (
 		<>
@@ -196,18 +193,19 @@ function Manage( { setRegenerating } ) {
 					code can only be used once.
 				</p>
 
-				{ remaining > 5 && (
+				{ backupCodesRemaining > 5 && (
 					<p>
-						You have <strong>{ remaining }</strong> backup codes remaining.
+						You have <strong>{ backupCodesRemaining }</strong> backup codes remaining.
 					</p>
 				) }
 
-				{ remaining <= 5 && (
+				{ backupCodesRemaining <= 5 && (
 					<Notice status="warning" isDismissible={ false }>
 						<Icon icon={ warning } />
-						You only have <strong>{ remaining }</strong> backup codes remaining. Please
-						regenerate and save new ones before you run out. If you don&apos;t, you
-						won&apos;t be able to log into your account if you lose your phone.
+						You only have <strong>{ backupCodesRemaining }</strong> backup codes
+						remaining. Please regenerate and save new ones before you run out. If you
+						don&apos;t, you won&apos;t be able to log into your account if you lose your
+						phone.
 					</Notice>
 				) }
 			</div>

--- a/settings/src/components/screen-link.js
+++ b/settings/src/components/screen-link.js
@@ -1,17 +1,23 @@
 /**
  * WordPress dependencies
  */
-import { useCallback, useContext } from '@wordpress/element';
+import { useCallback, useContext, useState } from '@wordpress/element';
+import { Spinner } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import { GlobalContext } from '../script';
+import { refreshRecord } from '../utilities/common';
 
 export default function ScreenLink( { screen, anchorText, buttonStyle = false, ariaLabel } ) {
-	const { navigateToScreen } = useContext( GlobalContext );
+	const {
+		user: { userRecord },
+		navigateToScreen,
+	} = useContext( GlobalContext );
 	const classes = [];
 	const screenUrl = new URL( document.location.href );
+	const [ refreshing, setRefreshing ] = useState( false );
 
 	screenUrl.searchParams.set( 'screen', screen );
 
@@ -24,11 +30,25 @@ export default function ScreenLink( { screen, anchorText, buttonStyle = false, a
 	}
 
 	const onClick = useCallback(
-		( event ) => {
+		async ( event ) => {
 			event.preventDefault();
+
+			if ( refreshing ) {
+				return;
+			}
+
+			setRefreshing( true );
+
+			// Sometimes the record will have been updated, and those changes need to be reflected on Account
+			// Status, but it's not possible for the current screen to refresh the record. For example, Backup
+			// Codes can't refresh it if the user generates codes but then clicks "Back" before clicking "All Finished".
+			if ( 'account-status' === screen ) {
+				await refreshRecord( userRecord );
+			}
+
 			navigateToScreen( screen );
 		},
-		[ navigateToScreen ]
+		[ navigateToScreen, userRecord, screen ]
 	);
 
 	return (
@@ -39,6 +59,8 @@ export default function ScreenLink( { screen, anchorText, buttonStyle = false, a
 			aria-label={ ariaLabel }
 		>
 			{ anchorText }
+
+			{ refreshing && <Spinner /> }
 		</a>
 	);
 }

--- a/settings/src/hooks/useUser.js
+++ b/settings/src/hooks/useUser.js
@@ -14,6 +14,7 @@ export function useUser( userId ) {
 
 	const availableProviders = userRecord.record?.[ '2fa_available_providers' ] ?? [];
 	const primaryProvider = userRecord.record?.[ '2fa_primary_provider' ] ?? null;
+	const backupCodesRemaining = userRecord.record?.[ '2fa_backup_codes_remaining' ] ?? 0;
 	const totpEnabled = availableProviders.includes( 'Two_Factor_Totp' );
 	const backupCodesEnabled = availableProviders.includes( 'Two_Factor_Backup_Codes' );
 	const webAuthnEnabled = availableProviders.includes( 'TwoFactor_Provider_WebAuthn' );
@@ -27,5 +28,6 @@ export function useUser( userId ) {
 		totpEnabled,
 		backupCodesEnabled,
 		webAuthnEnabled,
+		backupCodesRemaining,
 	};
 }


### PR DESCRIPTION
Fixes #244

This removes the local storage item, and instead uses the number of remaining backup codes to determine if the provider has already been setup. That comes from the database, so it spans browsers/devices/sessions.

I wasn't able to reproduce the bug mentioned in #221, so I don't think this will cause a regression, but I'd appreciate some more eyes to double check.

I initially ran into the bug from #217, but was able to fix that by refreshing the user when navigating to Account Status.