### PR TITLE
Make the disable button destructive.

### DIFF
--- a/settings/src/components/totp.js
+++ b/settings/src/components/totp.js
@@ -454,7 +454,7 @@ function ConfirmDisableApp( { onConfirm, onClose, disabling } ) {
 				</div>
 			) : (
 				<div className="wporg-2fa__submit-actions">
-					<Button variant="primary" onClick={ onConfirm }>
+					<Button variant="primary" isDestructive onClick={ onConfirm }>
 						Disable
 					</Button>
 

--- a/settings/src/components/webauthn/webauthn.js
+++ b/settings/src/components/webauthn/webauthn.js
@@ -190,7 +190,7 @@ function ConfirmDisableKeys( { onConfirm, onClose, disabling } ) {
 				</div>
 			) : (
 				<div className="wporg-2fa__submit-actions">
-					<Button variant="primary" onClick={ onConfirm }>
+					<Button variant="primary" isDestructive onClick={ onConfirm }>
 						Disable
 					</Button>
 


### PR DESCRIPTION
We introduced the `isDestructive` button prop in #237. This PR adds the same property to the modal that disable keys since it may affect the ability for users to log in. 


<img width="362" alt="Screenshot 2023-09-15 at 11 04 36 AM" src="https://github.com/WordPress/wporg-two-factor/assets/1657336/f4ded59d-5cd9-40be-ae51-f5f80b410bf3">
