### PR TITLE
Add new custom error for aborts.

### DIFF
--- a/settings/src/components/webauthn/register-key.js
+++ b/settings/src/components/webauthn/register-key.js
@@ -50,6 +50,18 @@ export default function RegisterKey( { onSuccess, onCancel } ) {
 
 				const credential = await navigator.credentials.create( { publicKey } );
 
+				/**
+				 * The navigator.credentials.create returns null if a Credential cannot be created.
+				 *
+				 * Since this is an interface we won't be able to predict the reason for the failure.
+				 * For now, we'll just throw an error and let the user try again.
+				 *
+				 * See: https://developer.mozilla.org/en-US/docs/Web/API/CredentialsContainer
+				 */
+				if ( null === credential ) {
+					throw new Error( 'Unable to create a security key.' );
+				}
+
 				await wp.ajax.post( 'webauthn_register', {
 					user_id: record.id,
 					_ajax_nonce: nonce,


### PR DESCRIPTION
When a user cancels out of creating a key, `await navigator.credentials.create( { publicKey } )` returns `null`. Currently, we don't check the return and pass it along to the `ajax` which returns a confusing error message. 

This PR improves the error message with one caveat. Since `navigator.credentials.create` is an interface, aborting is potentially not the only reason why the promise will return `null` so we can't assume its from the user aborting. Ideally, we don't show a message on abort but that likely isn't possible. 

| Before | After |
|--------|--------|
| <img width="774" alt="Screenshot 2023-09-15 at 11 48 35 AM" src="https://github.com/WordPress/wporg-two-factor/assets/1657336/b1e2233b-0ac6-4530-88d7-3ddd883aa5b0"> | <img width="771" alt="Screenshot 2023-09-15 at 11 48 13 AM" src="https://github.com/WordPress/wporg-two-factor/assets/1657336/734a2a39-633c-462c-862e-409bc4843bac"> | 



