### PR TITLE
Enable Backup Codes screen if user has primary provider

### DIFF
--- a/settings/src/components/account-status.js
+++ b/settings/src/components/account-status.js
@@ -88,7 +88,7 @@ export default function AccountStatus() {
 				status={ backupCodesEnabled }
 				headerText="Two-Factor Backup Codes"
 				bodyText={ backupBodyText }
-				disabled={ ! backupCodesEnabled }
+				disabled={ ! hasPrimaryProvider }
 			/>
 		</div>
 	);


### PR DESCRIPTION
Fixes #246 

Before this, it couldn't be accessed after the codes are deleted or expire.