### PR TITLE
Backup Codes: Show error when primary provider not enabled

### DIFF
--- a/settings/src/components/backup-codes.js
+++ b/settings/src/components/backup-codes.js
@@ -17,8 +17,7 @@ import { refreshRecord } from '../utilities/common';
  */
 export default function BackupCodes() {
 	const {
-		user: { backupCodesEnabled, totpEnabled },
-		navigateToScreen,
+		user: { backupCodesEnabled, hasPrimaryProvider },
 	} = useContext( GlobalContext );
 	const [ regenerating, setRegenerating ] = useState( false );
 	// TODO: hasSetupCompleted and its related logic should be removed
@@ -29,9 +28,8 @@ export default function BackupCodes() {
 		localStorage.getItem( 'WPORG_2FA_HAS_BACKUP_CODES_BEEN_SAVED' ) === 'true'
 	);
 
-	// If TOTP hasn't been enabled, the user should not have access to BackupCodes component.
-	// This is primarily added to prevent users from accessing through the URL.
-	if ( ! totpEnabled ) {
+	// Prevent users from accessing directly through the URL.
+	if ( ! hasPrimaryProvider ) {
 		navigateToScreen( 'account-status' );
 		return;
 	}

--- a/settings/src/components/backup-codes.js
+++ b/settings/src/components/backup-codes.js
@@ -11,6 +11,7 @@ import { Icon, warning, cancelCircleFilled } from '@wordpress/icons';
  */
 import { GlobalContext } from '../script';
 import { refreshRecord } from '../utilities/common';
+import ScreenLink from './screen-link';
 
 /**
  * Setup and manage backup codes.
@@ -30,8 +31,17 @@ export default function BackupCodes() {
 
 	// Prevent users from accessing directly through the URL.
 	if ( ! hasPrimaryProvider ) {
-		navigateToScreen( 'account-status' );
-		return;
+		return (
+			<Notice status="error" isDismissible={ false }>
+				<Icon icon={ cancelCircleFilled } />
+				Please
+				<ScreenLink
+					screen="account-status"
+					anchorText="enable a Two-Factor security key or app"
+				/>
+				before enabling backup codes.
+			</Notice>
+		);
 	}
 
 	if ( backupCodesEnabled && hasSetupCompleted && ! regenerating ) {

--- a/settings/src/style.scss
+++ b/settings/src/style.scss
@@ -93,6 +93,10 @@ $alert-blue: #72aee6;
 		margin: 0;
 	}
 
+	&.is-error a {
+		color: $gray-900; // The default blue is hard to read on the red background.
+	}
+
 	.components-notice__content {
 		display: flex;
 		align-items: center;


### PR DESCRIPTION
See #243 

This checks for `hasPrimaryProvider` instead of `totpEnabled`, so that users with WebAuthn instead of TOTP can enable backup codes.

It also shows an error message instead of redirecting, so the user knows what's happening and why. I feel like this is a better UX, but am open to other ideas. It's not essential to the PR.