### PR TITLE
Prevent CSS from loading on unrelated pages

### DIFF
--- a/settings/settings.php
+++ b/settings/settings.php
@@ -9,6 +9,7 @@ require __DIR__ . '/rest-api.php';
 
 add_action( 'plugins_loaded', __NAMESPACE__ . '\replace_core_ui_with_custom' ); // Must run after Two Factor plugin loaded.
 add_action( 'init', __NAMESPACE__ . '\register_block' );
+add_action( 'enqueue_block_assets', __NAMESPACE__ . '\maybe_dequeue_stylesheet', 40 );
 
 /**
  * Registers the block
@@ -144,4 +145,19 @@ function login_footer_revalidate_customizations() {
 		})();
 	</script>
 	<?php
+}
+
+/**
+ * Only load CSS when the block is actually used.
+ *
+ * Without this, the CSS will be loaded on every page, but it's only needed on the Account page.
+ *
+ * @todo this may not be necessary once https://github.com/WordPress/gutenberg/issues/54491 is resolved.
+ */
+function maybe_dequeue_stylesheet() {
+	if ( bbp_get_displayed_user_id() ) {
+		return;
+	}
+
+	wp_dequeue_style( 'wporg-two-factor-settings-style' );
 }


### PR DESCRIPTION
Fixes #35 

The check for `bbp_get_displayed_user_id()` isn't perfect, since it'll still load the stylesheet on a handful of pages that don't display the block. I think it's good enough for a quick workaround, though. Hopefully we can [move to `viewStyle` in the future](https://github.com/WordPress/gutenberg/issues/54491) and remove this code.

To test, look for the `wporg-two-factor-settings-style-css` stylesheet ID in response source, or the `wp-content/plugins/wporg-two-factor/settings/build/style-index.css` URL in the Network tab of browser dev tools.

```shell
> curl -is https://wpms.test/ | grep wporg-two-factor

> curl -is https://wpms.test/users/iandunn/edit/account/ | grep wporg-two-factor
<link rel='stylesheet' id='wporg-two-factor-settings-style-css' href='https://wpms.test/content/plugins/wporg-two-factor/settings/build/style-index.css?ver=0.1.3' type='text/css' media='all' />
```