### PR TITLE
Track if backup codes have been verified

### DIFF
--- a/settings/src/components/password.js
+++ b/settings/src/components/password.js
@@ -198,6 +198,10 @@ function isPasswordStrong( password, userData ) {
 		return false; // Not loaded yet.
 	}
 
+	if ( ! password || password.length === 0 ) {
+		return false;
+	}
+
 	let blocklist = Object.values(
 		pick( userData, [
 			'email',

--- a/settings/src/components/screen-link.js
+++ b/settings/src/components/screen-link.js
@@ -9,7 +9,7 @@ import { useCallback, useContext } from '@wordpress/element';
 import { GlobalContext } from '../script';
 
 export default function ScreenLink( { screen, anchorText, buttonStyle = false, ariaLabel } ) {
-	const { navigateToScreen } = useContext( GlobalContext );
+	const { navigateToScreen, setBackupCodesVerified } = useContext( GlobalContext );
 	const classes = [];
 	const screenUrl = new URL( document.location.href );
 
@@ -26,6 +26,12 @@ export default function ScreenLink( { screen, anchorText, buttonStyle = false, a
 	const onClick = useCallback(
 		( event ) => {
 			event.preventDefault();
+
+			// When generating Backup Codes, they're automatically saved to the database, so clicking `Back` is
+			// implicitly verifying them, or at least needs to be treated that way. This should be removed once
+			// `two-factor/#507` is fixed, though.
+			setBackupCodesVerified( true );
+
 			navigateToScreen( screen );
 		},
 		[ navigateToScreen ]

--- a/settings/src/script.js
+++ b/settings/src/script.js
@@ -61,6 +61,7 @@ function Main( { userId } ) {
 	} = user;
 	const [ globalNotice, setGlobalNotice ] = useState( '' );
 	const [ error, setError ] = useState( '' );
+	const [ backupCodesVerified, setBackupCodesVerified ] = useState( true );
 
 	let currentUrl = new URL( document.location.href );
 	const initialScreen = currentUrl.searchParams.get( 'screen' );
@@ -161,7 +162,15 @@ function Main( { userId } ) {
 
 	return (
 		<GlobalContext.Provider
-			value={ { navigateToScreen, user, setGlobalNotice, setError, error } }
+			value={ {
+				navigateToScreen,
+				user,
+				setGlobalNotice,
+				setError,
+				error,
+				backupCodesVerified,
+				setBackupCodesVerified,
+			} }
 		>
 			<GlobalNotice notice={ globalNotice } setNotice={ setGlobalNotice } />
 			{ currentScreenComponent }


### PR DESCRIPTION
One of the commits from #245 was reverted in 03ab8049852ff81af70f5c5d92682cf78af878ec. This achieves the same goal as that commit, but in a way that doesn't have the side-effects that it did.

It takes a similar conceptual approach to #221, where it keeps track of whether or not the codes have been verified. That can't be done in `BackupCodes`, though, because the state would get lost when clicking `Back`. It also can't do it in local storage, since that wouldn't persist across browsers.

This approach keeps the state in `Main` so that it won't get lost, but it ultimately relies on the database as the canonical source of truth. The user record is refreshed after saving the codes so that the system knows the user has them, but it also has the state of whether or not they've verified them. The combination of those two lets us achieve the original goal but without the side effects.

I also added some defensive code to the Password component. That's not necessary for the main fix here, it's just related because the need for it was exposed by the previous bug.

### Testing

1. Start without backup codes saved for the user
2. Visit the Backup Codes screen. Codes will automatically be generated and saved for the user.
3. Click `Back`. The Backup Codes status will show that it's active
4. Click on Backup Codes, and you'll see the Manage screen. Before the fix, you would have seen the Setup screen and new codes would have been saved

Also test that flow but with clicking `Finished`, and do some general tests to make sure there aren't any side-effects.