### PR TITLE
Add copy/print/download buttons to code backup.

### DIFF
--- a/settings/src/components/backup-codes.js
+++ b/settings/src/components/backup-codes.js
@@ -3,7 +3,7 @@
  */
 import apiFetch from '@wordpress/api-fetch';
 import { useContext, useCallback, useEffect, useState } from '@wordpress/element';
-import { Button, CheckboxControl, Notice, Spinner } from '@wordpress/components';
+import { Button, ButtonGroup, CheckboxControl, Flex, Notice, Spinner } from '@wordpress/components';
 import { Icon, warning, cancelCircleFilled } from '@wordpress/icons';
 
 /**
@@ -12,6 +12,9 @@ import { Icon, warning, cancelCircleFilled } from '@wordpress/icons';
 import { GlobalContext } from '../script';
 import { refreshRecord } from '../utilities/common';
 import ScreenLink from './screen-link';
+import CopyToClipboardButton from './copy-to-clipboard-button';
+import PrintButton from './print-button';
+import DownloadButton from './download-button';
 
 /**
  * Setup and manage backup codes.
@@ -147,7 +150,7 @@ function Setup( { setRegenerating } ) {
 				</>
 			) }
 
-			<p className="wporg-2fa__submit-actions">
+			<Flex align="center" className="wporg-2fa__submit-actions">
 				<Button
 					isPrimary={ hasPrinted }
 					isSecondary={ ! hasPrinted }
@@ -156,7 +159,13 @@ function Setup( { setRegenerating } ) {
 				>
 					All Finished
 				</Button>
-			</p>
+
+				<ButtonGroup>
+					<CopyToClipboardButton codes={ backupCodes } />
+					<PrintButton />
+					<DownloadButton codes={ backupCodes } />
+				</ButtonGroup>
+			</Flex>
 		</>
 	);
 }

--- a/settings/src/components/backup-codes.js
+++ b/settings/src/components/backup-codes.js
@@ -150,18 +150,13 @@ function Setup( { setRegenerating } ) {
 				</>
 			) }
 
-<<<<<<< HEAD
-			<Flex align="center" className="wporg-2fa__submit-actions">
+			<Flex justify="flex-start" align="center" className="wporg-2fa__submit-actions">
 				<Button
 					isPrimary={ hasPrinted }
 					isSecondary={ ! hasPrinted }
 					disabled={ ! hasPrinted }
 					onClick={ handleFinished }
 				>
-=======
-			<Flex justify="flex-start" align="center" className="wporg-2fa__submit-actions">
-				<Button isPrimary disabled={ ! hasPrinted } onClick={ handleFinished }>
->>>>>>> b65df39 (Update flex start.)
 					All Finished
 				</Button>
 

--- a/settings/src/components/backup-codes.js
+++ b/settings/src/components/backup-codes.js
@@ -150,6 +150,7 @@ function Setup( { setRegenerating } ) {
 				</>
 			) }
 
+<<<<<<< HEAD
 			<Flex align="center" className="wporg-2fa__submit-actions">
 				<Button
 					isPrimary={ hasPrinted }
@@ -157,6 +158,10 @@ function Setup( { setRegenerating } ) {
 					disabled={ ! hasPrinted }
 					onClick={ handleFinished }
 				>
+=======
+			<Flex justify="flex-start" align="center" className="wporg-2fa__submit-actions">
+				<Button isPrimary disabled={ ! hasPrinted } onClick={ handleFinished }>
+>>>>>>> b65df39 (Update flex start.)
 					All Finished
 				</Button>
 

--- a/settings/src/components/copy-to-clipboard-button.js
+++ b/settings/src/components/copy-to-clipboard-button.js
@@ -2,11 +2,7 @@
  * WordPress dependencies
  */
 import { useCallback, useState } from '@wordpress/element';
-
-/**
- * Internal dependencies
- */
-import { Button, Dashicon } from '@wordpress/components';
+import { Button } from '@wordpress/components';
 
 export default function CopyToClipboardButton( { codes } ) {
 	const [ copied, setCopied ] = useState( false );
@@ -20,17 +16,7 @@ export default function CopyToClipboardButton( { codes } ) {
 
 	return (
 		<Button variant="secondary" onClick={ onClick }>
-			{ copied ? (
-				<>
-					<Dashicon icon="yes" />
-					<span>Copied!</span>
-				</>
-			) : (
-				<>
-					<Dashicon icon="clipboard" />
-					<span className="screen-reader-text">Print</span>
-				</>
-			) }
+			{ copied ? 'Copied!' : 'Copy' }
 		</Button>
 	);
 }

--- a/settings/src/components/copy-to-clipboard-button.js
+++ b/settings/src/components/copy-to-clipboard-button.js
@@ -1,0 +1,36 @@
+/**
+ * WordPress dependencies
+ */
+import { useCallback, useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { Button, Dashicon } from '@wordpress/components';
+
+export default function CopyToClipboardButton( { codes } ) {
+	const [ copied, setCopied ] = useState( false );
+
+	const onClick = useCallback( () => {
+		navigator.clipboard.writeText( codes ).then( () => {
+			setCopied( true );
+			setTimeout( () => setCopied( false ), 2000 );
+		} );
+	}, [ codes ] );
+
+	return (
+		<Button variant="secondary" onClick={ onClick }>
+			{ copied ? (
+				<>
+					<Dashicon icon="yes" />
+					<span>Copied!</span>
+				</>
+			) : (
+				<>
+					<Dashicon icon="clipboard" />
+					<span className="screen-reader-text">Print</span>
+				</>
+			) }
+		</Button>
+	);
+}

--- a/settings/src/components/download-button.js
+++ b/settings/src/components/download-button.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useCallback } from '@wordpress/element';
-import { Button, Dashicon } from '@wordpress/components';
+import { Button } from '@wordpress/components';
 
 export default function DownloadTxtButton( { codes, fileName = 'backup-codes.txt' } ) {
 	const downloadTxtFile = useCallback( () => {
@@ -17,8 +17,7 @@ export default function DownloadTxtButton( { codes, fileName = 'backup-codes.txt
 
 	return (
 		<Button variant="secondary" onClick={ downloadTxtFile }>
-			<Dashicon icon="download" />
-			<span className="screen-reader-text">Download</span>
+			Download
 		</Button>
 	);
 }

--- a/settings/src/components/download-button.js
+++ b/settings/src/components/download-button.js
@@ -1,0 +1,24 @@
+/**
+ * WordPress dependencies
+ */
+import { useCallback } from '@wordpress/element';
+import { Button, Dashicon } from '@wordpress/components';
+
+export default function DownloadTxtButton( { codes, fileName = 'backup-codes.txt' } ) {
+	const downloadTxtFile = useCallback( () => {
+		const element = document.createElement( 'a' );
+		const file = new Blob( [ codes ], { type: 'text/plain' } );
+		element.href = URL.createObjectURL( file );
+		element.download = fileName;
+		document.body.appendChild( element ); // Required for Firefox
+		element.click();
+		document.body.removeChild( element );
+	}, [ codes, fileName ] );
+
+	return (
+		<Button variant="secondary" onClick={ downloadTxtFile }>
+			<Dashicon icon="download" />
+			<span className="screen-reader-text">Download</span>
+		</Button>
+	);
+}

--- a/settings/src/components/print-button.js
+++ b/settings/src/components/print-button.js
@@ -1,0 +1,18 @@
+/**
+ * WordPress dependencies
+ */
+import { useCallback } from '@wordpress/element';
+import { Button, Dashicon } from '@wordpress/components';
+
+export default function PrintButton() {
+	const onClick = useCallback( () => {
+		window.print();
+	}, [] );
+
+	return (
+		<Button onClick={ onClick } variant="secondary">
+			<Dashicon icon="printer" />
+			<span className="screen-reader-text">Print</span>
+		</Button>
+	);
+}

--- a/settings/src/components/print-button.js
+++ b/settings/src/components/print-button.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useCallback } from '@wordpress/element';
-import { Button, Dashicon } from '@wordpress/components';
+import { Button } from '@wordpress/components';
 
 export default function PrintButton() {
 	const onClick = useCallback( () => {
@@ -11,8 +11,7 @@ export default function PrintButton() {
 
 	return (
 		<Button onClick={ onClick } variant="secondary">
-			<Dashicon icon="printer" />
-			<span className="screen-reader-text">Print</span>
+			Print
 		</Button>
 	);
 }


### PR DESCRIPTION
Fixes: https://github.com/WordPress/wporg-two-factor/issues/45

This PR adds a copy, print, and download button to the backup code page.

The only downside is that `@wordpress/icons` doesn't have a print icon and we get a weird layout if we combine `<Icon>` with `<Dashicon>`, so I've started with using dashicons.

@WordPress/meta-design Do we have a print `<svg>` that I can use?

## Screenshot

<img width="954" alt="Screenshot 2024-07-10 at 1 39 53 PM" src="https://github.com/WordPress/wporg-two-factor/assets/1657336/ea7625b5-e7f3-487b-b058-0378eb3bc14e">
