### PR TITLE
Remove the "Revalidation complete" notice

### DIFF
--- a/settings/src/components/revalidate-modal.js
+++ b/settings/src/components/revalidate-modal.js
@@ -35,7 +35,9 @@ export default function RevalidateModal() {
 }
 
 function RevalidateIframe() {
-	const { user: { userRecord } } = useContext( GlobalContext );
+	const {
+		user: { userRecord },
+	} = useContext( GlobalContext );
 	const { record } = userRecord;
 	const ref = useRef();
 

--- a/settings/src/components/revalidate-modal.js
+++ b/settings/src/components/revalidate-modal.js
@@ -43,12 +43,10 @@ function RevalidateIframe() {
 	const ref = useRef();
 
 	useEffect( () => {
-		async function maybeRefreshUser( { data: { type, message } = {} } ) {
+		async function maybeRefreshUser( { data: { type } = {} } ) {
 			if ( type !== 'reValidationComplete' ) {
 				return;
 			}
-
-			setGlobalNotice( message || 'Two-Factor confirmed' );
 
 			// Pretend that the expires_at is in the future (+1hr), this provides a 'faster' UI.
 			// This intentionally doesn't use `edit()` to prevent it attempting to update it on the server.

--- a/settings/src/components/revalidate-modal.js
+++ b/settings/src/components/revalidate-modal.js
@@ -35,10 +35,7 @@ export default function RevalidateModal() {
 }
 
 function RevalidateIframe() {
-	const {
-		setGlobalNotice,
-		user: { userRecord },
-	} = useContext( GlobalContext );
+	const { user: { userRecord } } = useContext( GlobalContext );
 	const { record } = userRecord;
 	const ref = useRef();
 


### PR DESCRIPTION
This potentially removes other notices from the Two Factor plugin, as the message could be something other than "revalidation complete" but given the context, I think it's pretty unlikely that's going to happen.

Fixes #277