### PR TITLE
Fix pending verified state.

### DIFF
--- a/settings/src/components/account-status.js
+++ b/settings/src/components/account-status.js
@@ -82,7 +82,9 @@ export default function AccountStatus() {
 
 			<SettingStatusCard
 				screen="backup-codes"
-				status={ ! hasPrimaryProvider ? 'pending' : backupCodesEnabled }
+				status={
+					! hasPrimaryProvider && ! backupCodesEnabled ? 'pending' : backupCodesEnabled
+				}
 				headerText="Two-Factor Backup Codes"
 				bodyText={ backupBodyText }
 				disabled={ ! hasPrimaryProvider }


### PR DESCRIPTION
If you have verified your backup codes but delete all providers, you get a weird state where we show a warning icon.
<img width="977" alt="Screenshot 2024-08-12 at 1 38 53 PM" src="https://github.com/user-attachments/assets/9f756b04-4576-49d4-a376-8716f9d96ab2">

It should only show the warning if backup codes have not been enabled yet.

<img width="987" alt="Screenshot 2024-08-12 at 1 40 08 PM" src="https://github.com/user-attachments/assets/255a8891-cc9b-4413-b8bd-cb020a4202e7">
