### PR TITLE
Move backup code actions directly below codes

### DIFF
--- a/settings/src/components/backup-codes.js
+++ b/settings/src/components/backup-codes.js
@@ -134,6 +134,12 @@ function Setup( { setRegenerating } ) {
 				<>
 					<CodeList codes={ backupCodes } />
 
+					<ButtonGroup>
+						<CopyToClipboardButton codes={ backupCodes } />
+						<PrintButton />
+						<DownloadButton codes={ backupCodes } />
+					</ButtonGroup>
+
 					<Notice status="warning" isDismissible={ false }>
 						<Icon icon={ warning } className="wporg-2fa__print-codes-warning" />
 						Without access to the one-time password app or a backup code, you will lose
@@ -159,12 +165,6 @@ function Setup( { setRegenerating } ) {
 				>
 					All Finished
 				</Button>
-
-				<ButtonGroup>
-					<CopyToClipboardButton codes={ backupCodes } />
-					<PrintButton />
-					<DownloadButton codes={ backupCodes } />
-				</ButtonGroup>
 			</Flex>
 		</>
 	);

--- a/settings/src/components/backup-codes.scss
+++ b/settings/src/components/backup-codes.scss
@@ -1,7 +1,10 @@
 .wporg-2fa__backup-codes {
+	> * {
+		margin-bottom: 1em;
+	}
+
 	.wporg-2fa__backup-codes-list {
 		background-color: $gray-300;
-		margin: 1em 0;
 		padding: 15px 20px;
 
 		ol {
@@ -17,10 +20,6 @@
 		    */
 			color: $gray-700;
 		}
-	}
-
-	.components-notice {
-		margin: 0 0 1em;
 	}
 }
 


### PR DESCRIPTION
Fixes #294

I initially based this on the [wizard PR](https://github.com/WordPress/wporg-two-factor/pull/286/), and it worked fine. Changed to trunk so we can improve this immediately.

![Screenshot 2024-08-14 at 11 28 20 AM](https://github.com/user-attachments/assets/8303aa28-849f-4e14-b1e3-5fb2c3ead6ab)
