### PR TITLE
Only create backup codes when user initiated

### DIFF
--- a/settings/src/components/backup-codes.js
+++ b/settings/src/components/backup-codes.js
@@ -237,7 +237,9 @@ function Manage( { setGenerating } ) {
 			</div>
 
 			<Button isSecondary onClick={ () => setGenerating( true ) }>
-				{ backupCodesEnabled ? 'Regenerate backup codes' : 'Generate backup codes' }
+				{ backupCodesEnabled
+					? 'Regenerate and save backup codes'
+					: 'Generate and save backup codes' }
 			</Button>
 		</>
 	);

--- a/settings/src/components/backup-codes.js
+++ b/settings/src/components/backup-codes.js
@@ -132,12 +132,6 @@ function Setup( { setGenerating, onSuccess } ) {
 				<>
 					<CodeList codes={ backupCodes } />
 
-					<ButtonGroup>
-						<CopyToClipboardButton contents={ backupCodes } />
-						<PrintButton />
-						<DownloadButton codes={ backupCodes } />
-					</ButtonGroup>
-
 					<CheckboxControl
 						label="I have printed or saved these codes"
 						checked={ hasPrinted }
@@ -162,33 +156,41 @@ function Setup( { setGenerating, onSuccess } ) {
 }
 
 /**
- * Display a list of backup codes
+ * Display a list of backup codes and actions
  *
  * @param props
  * @param props.codes
  */
 function CodeList( { codes } ) {
-	return (
-		<div className="wporg-2fa__backup-codes-list">
-			{ ! codes.length && (
-				<p>
-					Generating backup codes...
-					<Spinner />
-				</p>
-			) }
+	const hasCodes = !! codes.length;
 
-			{ codes.length > 0 && (
-				<ol>
-					{ codes.map( ( code ) => {
-						return (
-							<li key={ code } className="wporg-2fa__token">
-								{ code.slice( 0, 4 ) + ' ' + code.slice( 4 ) }
-							</li>
-						);
-					} ) }
-				</ol>
+	return (
+		<>
+			<div className="wporg-2fa__backup-codes-list">
+				{ hasCodes ? (
+					<ol>
+						{ codes.map( ( code ) => {
+							return (
+								<li key={ code } className="wporg-2fa__token">
+									{ code.slice( 0, 4 ) + ' ' + code.slice( 4 ) }
+								</li>
+							);
+						} ) }
+					</ol>
+				) : (
+					<p>
+						<Spinner /> Generating backup codes...
+					</p>
+				) }
+			</div>
+			{ hasCodes && (
+				<ButtonGroup>
+					<CopyToClipboardButton contents={ codes } />
+					<PrintButton />
+					<DownloadButton codes={ codes } />
+				</ButtonGroup>
 			) }
-		</div>
+		</>
 	);
 }
 

--- a/settings/src/components/backup-codes.js
+++ b/settings/src/components/backup-codes.js
@@ -24,10 +24,9 @@ import DownloadButton from './download-button';
  */
 export default function BackupCodes( { onSuccess = () => {} } ) {
 	const {
-		user: { backupCodesEnabled, hasPrimaryProvider, backupCodesRemaining },
-		backupCodesVerified,
+		user: { hasPrimaryProvider },
 	} = useContext( GlobalContext );
-	const [ regenerating, setRegenerating ] = useState( false );
+	const [ generating, setGenerating ] = useState( false );
 
 	// Prevent users from accessing directly through the URL.
 	if ( ! hasPrimaryProvider ) {
@@ -41,26 +40,21 @@ export default function BackupCodes( { onSuccess = () => {} } ) {
 		);
 	}
 
-	if (
-		! backupCodesEnabled ||
-		backupCodesRemaining === 0 ||
-		regenerating ||
-		! backupCodesVerified
-	) {
-		return <Setup setRegenerating={ setRegenerating } onSuccess={ onSuccess } />;
-	}
-
-	return <Manage setRegenerating={ setRegenerating } />;
+	return generating ? (
+		<Setup setGenerating={ setGenerating } onSuccess={ onSuccess } />
+	) : (
+		<Manage setGenerating={ setGenerating } />
+	);
 }
 
 /**
  * Setup the Backup Codes provider.
  *
  * @param props
- * @param props.setRegenerating
+ * @param props.setGenerating
  * @param props.onSuccess
  */
-function Setup( { setRegenerating, onSuccess } ) {
+function Setup( { setGenerating, onSuccess } ) {
 	const {
 		setGlobalNotice,
 		user: { userRecord },
@@ -110,18 +104,14 @@ function Setup( { setRegenerating, onSuccess } ) {
 		// The codes have already been saved to usermeta, see `generateCodes()` above.
 		setBackupCodesVerified( true );
 		setGlobalNotice( 'Backup codes have been enabled.' );
-		setRegenerating( false );
+		setGenerating( false );
 		onSuccess();
 	} );
 
 	return (
 		<>
 			<div className="wporg-2fa__screen-intro">
-				<p>
-					Backup codes let you access your account if your primary two-factor
-					authentication method is unavailable, like if your phone is lost or stolen. Each
-					code can only be used once.
-				</p>
+				<IntroText />
 
 				<p>Please print the codes and keep them in a safe place.</p>
 
@@ -202,33 +192,36 @@ function CodeList( { codes } ) {
 	);
 }
 
+const IntroText = () => (
+	<p>
+		Backup codes let you access your account if your primary two-factor authentication method is
+		unavailable, like if your phone is lost or stolen. Each code can only be used once.
+	</p>
+);
+
 /**
  * Render the screen where users can manage Backup Codes.
  *
  * @param props
- * @param props.setRegenerating
+ * @param props.setGenerating
  */
-function Manage( { setRegenerating } ) {
+function Manage( { setGenerating } ) {
 	const {
-		user: { backupCodesRemaining },
+		user: { backupCodesEnabled, backupCodesRemaining },
 	} = useContext( GlobalContext );
 
 	return (
 		<>
 			<div className="wporg-2fa__screen-intro">
-				<p>
-					Backup codes let you access your account if your primary two-factor
-					authentication method is unavailable, like if your phone is lost or stolen. Each
-					code can only be used once.
-				</p>
+				<IntroText />
 
-				{ backupCodesRemaining > 5 && (
+				{ backupCodesEnabled && backupCodesRemaining > 5 && (
 					<p>
 						You have <strong>{ backupCodesRemaining }</strong> backup codes remaining.
 					</p>
 				) }
 
-				{ backupCodesRemaining <= 5 && (
+				{ backupCodesEnabled && backupCodesRemaining <= 5 && (
 					<Notice status="warning" isDismissible={ false }>
 						<Icon icon={ warning } />
 						<div>
@@ -241,8 +234,8 @@ function Manage( { setRegenerating } ) {
 				) }
 			</div>
 
-			<Button isSecondary onClick={ () => setRegenerating( true ) }>
-				Generate new backup codes
+			<Button isSecondary onClick={ () => setGenerating( true ) }>
+				{ backupCodesEnabled ? 'Regenerate backup codes' : 'Generate backup codes' }
 			</Button>
 		</>
 	);

--- a/settings/src/components/settings.js
+++ b/settings/src/components/settings.js
@@ -21,7 +21,11 @@ import { GlobalContext } from '../script';
  * Render the correct component based on the URL.
  */
 export default function Settings() {
-	const { backupCodesEnabled, navigateToScreen, screen } = useContext( GlobalContext );
+	const {
+		user: { backupCodesEnabled },
+		navigateToScreen,
+		screen,
+	} = useContext( GlobalContext );
 
 	// The index is the URL slug and the value is the React component.
 	const components = {


### PR DESCRIPTION
Fixes #250 

Changes the backup codes screen to not generate codes on load. Instead the `Generate codes` button must be activated. Once backup codes have been enabled the button text changes to `Regenerate codes` as before.

Improves the UI by not rendering the action buttons until the codes are available.

| Pre-generation | Enabled |
|--------|--------|
| ![Screenshot 2024-08-14 at 1 48 57 PM](https://github.com/user-attachments/assets/97a95896-fa7f-4e98-af0e-075acdeb5665) | ![Screenshot 2024-08-14 at 1 49 27 PM](https://github.com/user-attachments/assets/3f1e827c-f5ff-49ad-8b14-b8dfcf589fd4) | 