### PR TITLE
Add initial load container to react app loader to avoid content shift.

### DIFF
--- a/settings/src/script.js
+++ b/settings/src/script.js
@@ -139,7 +139,11 @@ function Main( { userId } ) {
 	);
 
 	if ( ! hasResolved ) {
-		return <Spinner />;
+		return (
+			<div className="initial-load">
+				<Spinner />
+			</div>
+		);
 	}
 
 	const currentScreenComponent =


### PR DESCRIPTION
We render HTML then replace with the React app. As such, we have 2 different loading states.

This PR adds the same wrapper to the spinner within the react app which causes content layout shifts. It's particularly visible on slower connections.


| Before GIF | After GIF |
|--------|--------|
| ![Screen Capture on 2024-08-16 at 14-05-58](https://github.com/user-attachments/assets/ff09c5f6-c7d3-4f22-a028-151ae2b5e761) | ![Screen Capture on 2024-08-16 at 14-05-12](https://github.com/user-attachments/assets/e022c9c3-431b-482f-888f-4a36b16125f1) | 


