### PR TITLE
Move up warning message on backup code screen.

### DIFF
--- a/settings/src/components/backup-codes.js
+++ b/settings/src/components/backup-codes.js
@@ -123,6 +123,13 @@ function Setup( { setRegenerating } ) {
 				</p>
 
 				<p>Please print the codes and keep them in a safe place.</p>
+
+				<Notice status="warning" isDismissible={ false }>
+					<Icon icon={ warning } className="wporg-2fa__print-codes-warning" />
+					Without access to the one-time password app or a backup code, you will lose
+					access to your account. Once you navigate away from this page, you will not be
+					be able to view these codes again.
+				</Notice>
 			</div>
 
 			{ error ? (
@@ -139,13 +146,6 @@ function Setup( { setRegenerating } ) {
 						<PrintButton />
 						<DownloadButton codes={ backupCodes } />
 					</ButtonGroup>
-
-					<Notice status="warning" isDismissible={ false }>
-						<Icon icon={ warning } className="wporg-2fa__print-codes-warning" />
-						Without access to the one-time password app or a backup code, you will lose
-						access to your account. Once you navigate away from this page, you will not
-						be able to view these codes again.
-					</Notice>
 
 					<CheckboxControl
 						label="I have printed or saved these codes"

--- a/settings/src/components/backup-codes.scss
+++ b/settings/src/components/backup-codes.scss
@@ -5,6 +5,7 @@
 
 	.wporg-2fa__backup-codes-list {
 		background-color: $gray-300;
+		margin-top: 24px;
 		padding: 15px 20px;
 
 		ol {


### PR DESCRIPTION
With the copy/print/download buttons moving up below the codes, the banner creates a lot of vision disruption. In addition, when this view is displayed the backups are already set, so we want users to see that banner as early as possible so they don't navigate back out.


| Before | After |
|--------|--------|
| <img width="774" alt="Screenshot 2024-08-22 at 3 46 03 PM" src="https://github.com/user-attachments/assets/14e0b47a-0373-4181-9950-bf5ddbd1b000"> | <img width="785" alt="Screenshot 2024-08-22 at 3 45 13 PM" src="https://github.com/user-attachments/assets/4e655273-1f1d-434b-a827-e7423f82cbd3"> | 

