### PR TITLE
Redirect to backup codes for webauthn if none setup.

### DIFF
--- a/settings/src/components/settings.js
+++ b/settings/src/components/settings.js
@@ -38,8 +38,16 @@ export default function Settings() {
 				} }
 			/>
 		),
+		webauthn: (
+			<WebAuthn
+				onKeyAdd={ () => {
+					if ( ! backupCodesEnabled ) {
+						navigateToScreen( 'backup-codes' );
+					}
+				} }
+			/>
+		),
 		'backup-codes': <BackupCodes onSuccess={ () => navigateToScreen( 'home' ) } />,
-		webauthn: <WebAuthn />,
 	};
 
 	const currentScreenComponent =


### PR DESCRIPTION
Fixes: #253

This PR hooks into the `<WebAuthn>` `onKeyAdd` function added in #297 to redirect users to `<BackupCodes>` if they don't have backup codes installed yet.
