### PR TITLE
Stats: Add stats to determine if the post-login nag/reminders are effective

### DIFF
--- a/stats.php
+++ b/stats.php
@@ -1,10 +1,6 @@
 <?php
 namespace WordPressdotorg\Two_Factor\Stats;
-
-use Two_Factor_Core, Two_Factor_Backup_Codes;
-use WildWolf\WordPress\TwoFactorWebAuthn\Plugin as WebAuthn_Plugin;
-use WildWolf\WordPress\TwoFactorWebAuthn\Constants as WebAuthn_Plugin_Constants;
-use WP_User, WP_Error;
+use stdClass;
 
 defined( 'WPINC' ) || die();
 
@@ -13,6 +9,7 @@ if ( ! function_exists( 'bump_stats_extra' ) ) {
 }
 
 add_action( 'two_factor_user_authenticated', __NAMESPACE__ . '\two_factor_user_authenticated', 10, 2 );
+add_action( 'update_user_meta', __NAMESPACE__ . '\action_update_user_meta', 10, 4 );
 
 /**
  * Record stats for number of authentications per provider per day.
@@ -28,3 +25,56 @@ function two_factor_user_authenticated( $user_id, $provider ) {
 	bump_stats_extra( 'two-factor-auth', $provider );
 }
 
+/**
+ * Watch for changes to user meta.
+ *
+ * Currently this only records stats for:
+ *  - Enabled 2FA after being nagged about it on login
+ *  - Generated backup codes after being nagged about it on login
+ */
+function action_update_user_meta( $meta_id, $user_id, $meta_key, $new_meta_value ) {
+	$relevant_meta_keys = [
+		'_two_factor_backup_codes',
+		'_two_factor_enabled_providers'
+	];
+	if ( ! in_array( $meta_key, $relevant_meta_keys, true ) ) {
+		return;
+	}
+
+	$nag_user_meta = ( '_two_factor_backup_codes' === $meta_key ) ? 'last_2fa_backup_codes_nag_time' : 'last_2fa_nag';
+	$last_nagged   = get_user_meta( $user_id, $nag_user_meta, true );
+
+	// The user was last nagged more than an hour ago, the stats here aren't relevant.
+	if ( $last_nagged && $last_nagged < time() - HOUR_IN_SECONDS ) {
+		return;
+	}
+
+	$old_meta_key   = $meta_key;
+	$old_meta_value = get_user_meta( $user_id, $meta_key, true );
+	$callback       = new stdClass; // Placeholder for the callback, such that it can be used in the callback.
+	$callback       = static function( $meta_id, $user_id, $meta_key, $new_meta_value ) use( $old_meta_value, $old_meta_key, &$callback ) {
+		if ( $old_meta_key != $meta_key ) {
+			return;
+		}
+		remove_action( 'updated_user_meta', $callback ); // Remove self.
+
+		// The user has set new backup codes.
+		if ( '_two_factor_backup_codes' === $meta_key ) {
+			bump_stats_extra( 'wporg-two-factor', 'Set Backup Codes after nag' );
+		}
+
+		// The user has enabled or disabled providers.
+		if ( '_two_factor_enabled_providers' === $meta_key ) {
+			$old_providers      = $old_meta_value ?? [];
+			$new_providers      = $new_meta_value ?? [];
+			$enabled_providers  = array_diff( $new_providers, $old_providers );
+
+			foreach ( $enabled_providers as $provider ) {
+				$provider_name = str_replace( '_', ' ', str_ireplace( [ 'TwoFactor_Provider_', 'Two_Factor_' ], '', $provider ) );
+				bump_stats_extra( 'wporg-two-factor', "Set $provider_name after nag" );
+			}
+		}
+	};
+
+	add_action( 'updated_user_meta', $callback, 10, 4 );
+}

--- a/stats.php
+++ b/stats.php
@@ -1,0 +1,30 @@
+<?php
+namespace WordPressdotorg\Two_Factor\Stats;
+
+use Two_Factor_Core, Two_Factor_Backup_Codes;
+use WildWolf\WordPress\TwoFactorWebAuthn\Plugin as WebAuthn_Plugin;
+use WildWolf\WordPress\TwoFactorWebAuthn\Constants as WebAuthn_Plugin_Constants;
+use WP_User, WP_Error;
+
+defined( 'WPINC' ) || die();
+
+if ( ! function_exists( 'bump_stats_extra' ) ) {
+	return;
+}
+
+add_action( 'two_factor_user_authenticated', __NAMESPACE__ . '\two_factor_user_authenticated', 10, 2 );
+
+/**
+ * Record stats for number of authentications per provider per day.
+ */
+function two_factor_user_authenticated( $user_id, $provider ) {
+	if ( ! $provider ) {
+		return;
+	}
+
+	$provider = str_ireplace( [ 'TwoFactor_Provider_', 'Two_Factor_' ], '', $provider->get_key() );
+	$provider = str_replace( '_', ' ', $provider );
+
+	bump_stats_extra( 'two-factor-auth', $provider );
+}
+

--- a/stats.php
+++ b/stats.php
@@ -12,6 +12,16 @@ add_action( 'two_factor_user_authenticated', __NAMESPACE__ . '\two_factor_user_a
 add_action( 'update_user_meta', __NAMESPACE__ . '\action_update_user_meta', 10, 4 );
 
 /**
+ * Convert a Provider class name into a friendly nice name.
+ *
+ * @param string $provider
+ * @return string
+ */
+function provider_name_from_key( $provider ) {
+	return str_replace( '_', ' ', str_ireplace( [ 'TwoFactor_Provider_', 'Two_Factor_' ], '', $provider ) );
+}
+
+/**
  * Record stats for number of authentications per provider per day.
  */
 function two_factor_user_authenticated( $user_id, $provider ) {
@@ -19,10 +29,7 @@ function two_factor_user_authenticated( $user_id, $provider ) {
 		return;
 	}
 
-	$provider = str_ireplace( [ 'TwoFactor_Provider_', 'Two_Factor_' ], '', $provider->get_key() );
-	$provider = str_replace( '_', ' ', $provider );
-
-	bump_stats_extra( 'two-factor-auth', $provider );
+	bump_stats_extra( 'two-factor-auth', provider_name_from_key( $provider->get_key() ) );
 }
 
 /**
@@ -69,9 +76,8 @@ function action_update_user_meta( $meta_id, $user_id, $meta_key, $new_meta_value
 			$new_providers      = $new_meta_value ?? [];
 			$enabled_providers  = array_diff( $new_providers, $old_providers );
 
-			foreach ( $enabled_providers as $provider ) {
-				$provider_name = str_replace( '_', ' ', str_ireplace( [ 'TwoFactor_Provider_', 'Two_Factor_' ], '', $provider ) );
-				bump_stats_extra( 'wporg-two-factor', "Set $provider_name after nag" );
+			foreach ( $enabled_providers as $provider_key ) {
+				bump_stats_extra( 'wporg-two-factor', 'Set ' . provider_name_from_key( $provider_key ) . ' after nag' );
 			}
 		}
 	};

--- a/wporg-two-factor.php
+++ b/wporg-two-factor.php
@@ -29,6 +29,7 @@ function is_2fa_beta_tester( $user = false ) : bool {
 }
 
 require_once __DIR__ . '/settings/settings.php';
+require_once __DIR__ . '/stats.php';
 
 /**
  * Load the WebAuthn plugin.
@@ -76,7 +77,6 @@ add_action( 'set_current_user', __NAMESPACE__ . '\remove_super_admins_until_2fa_
 add_action( 'login_redirect', __NAMESPACE__ . '\redirect_to_2fa_settings', 105, 3 ); // After `wporg_remember_where_user_came_from_redirect()`, before `WP_WPorg_SSO::redirect_to_policy_update()`.
 add_action( 'user_has_cap', __NAMESPACE__ . '\remove_capabilities_until_2fa_enabled', 99, 4 ); // Must run _after_ all other plugins.
 add_action( 'current_screen', __NAMESPACE__ . '\block_webauthn_settings_page' );
-add_action( 'two_factor_user_authenticated', __NAMESPACE__ . '\two_factor_user_authenticated', 10, 2 );
 
 /**
  * Determine which providers should be available to users.
@@ -431,20 +431,6 @@ function after_provider_deactivated( $user_id, $provider = null ) {
 			'two-factor-login'    => null,
 		] );
 	}
-}
-
-/**
- * Record stats for number of authentications per provider per day.
- */
-function two_factor_user_authenticated( $user_id, $provider ) {
-	if ( ! function_exists( 'bump_stats_extra' ) || ! $provider ) {
-		return;
-	}
-
-	$provider = str_ireplace( [ 'TwoFactor_Provider_', 'Two_Factor_' ], '', $provider->get_key() );
-	$provider = str_replace( '_', ' ', $provider );
-
-	bump_stats_extra( 'two-factor-auth', $provider );
 }
 
 /*


### PR DESCRIPTION
Adds stats to verify if the login nags (#279 and https://github.com/WordPress/wordpress.org/pull/351 ) are being effective or not.

Combined with the nag date, and the knowledge of who is being nagged, we'll be able to determine if users are following through with the prompts and who is skipping over it.