### PR TITLE
Reduce the content.

### DIFF
--- a/settings/src/components/account-status.js
+++ b/settings/src/components/account-status.js
@@ -34,7 +34,7 @@ export default function AccountStatus() {
 			? 'Please enable a Two-Factor security key or app before enabling backup codes.'
 			: `You have
 				${ backupCodesEnabled ? '' : 'not' }
-				verified your backup codes for two-factor authentication.`;
+				verified your backup codes.`;
 
 	return (
 		<div className={ 'wporg-2fa__account-status' }>
@@ -63,7 +63,7 @@ export default function AccountStatus() {
 				bodyText={
 					webAuthnEnabled
 						? 'You have two-factor authentication enabled using security keys.'
-						: 'You have not enabled security keys for two-factor authentication.'
+						: 'You have not enabled security keys.'
 				}
 				isPrimary={ 'TwoFactor_Provider_WebAuthn' === primaryProvider && totpEnabled }
 			/>
@@ -75,7 +75,7 @@ export default function AccountStatus() {
 				bodyText={
 					totpEnabled
 						? 'You have two-factor authentication enabled using an app.'
-						: 'You have not enabled an app for two-factor authentication.'
+						: 'You have not enabled an app.'
 				}
 				isPrimary={ 'Two_Factor_Totp' === primaryProvider && webAuthnEnabled }
 			/>


### PR DESCRIPTION
This PR removes ` for two-factor authentication` from the account status secondary copy because to me, it feels redundant since the titles all include "Two-factor".


| Before | After |
|--------|--------|
| <img width="790" alt="Screenshot 2024-08-30 at 11 25 05 AM" src="https://github.com/user-attachments/assets/fa3b5d32-f483-4198-90f5-13898f05c4e2"> | <img width="781" alt="Screenshot 2024-08-30 at 11 15 22 AM" src="https://github.com/user-attachments/assets/66faaa06-09d4-43fe-98ea-152f85fe0d0e"> | 



