### PR TITLE
Update 'You've got' to 'you have'.

### DIFF
--- a/settings/src/components/account-status.js
+++ b/settings/src/components/account-status.js
@@ -105,7 +105,7 @@ export default function AccountStatus() {
 					bodyText={
 						! svnPasswordSet
 							? 'You have not configured a SVN password for your account.'
-							: "You've got a SVN password configured for your account."
+							: 'You have an SVN password configured for your account.'
 					}
 				/>
 			) : (


### PR DESCRIPTION
Update string `You've got a SVN password configured for your account.` to `You have an SVN password configured for your account.`.

I know it's less punchy but consistent with the other status messages.

cc @dd32 