### PR TITLE
Enable the "please enable 2FA" login nag for plugin + theme authors.

### DIFF
--- a/wporg-two-factor.php
+++ b/wporg-two-factor.php
@@ -273,19 +273,17 @@ function user_should_2fa( $user ) : bool {
 		return true;
 	}
 
-	/*
 	// If a user ... they should have 2FA enabled.
 	if (
 		// Is (or was) a plugin committer
 		$user->has_plugins ||
 		// Has (or had) a live theme
-		$user->has_themes ||
+		$user->has_themes /* ||
 		// Has (or had) an elevated role on a site (WordPress.org, BuddyPress.org, bbPress.org, WordCamp.org)
-		$user->has_elevated_role
+		$user->has_elevated_role */
 	) {
 		return true;
 	}
- 	*/
 
 	return false;
 }


### PR DESCRIPTION
It's time to flick on the login nag for Plugin and Theme authors, now that it's been announced:
https://make.wordpress.org/plugins/2024/09/04/upcoming-security-changes-for-plugin-and-theme-authors-on-wordpress-org/

This will trigger the 'enable 2fa please' notice on login.