### PR TITLE
Plugin & Theme authors are now required to have 2FA enabled.

### DIFF
--- a/wporg-two-factor.php
+++ b/wporg-two-factor.php
@@ -241,9 +241,7 @@ function user_requires_2fa( $user ) : bool {
 		// Is (or was) a plugin committer
 		$user->has_plugins ||
 		// Has (or had) a live theme
-		$user->has_themes /* ||
-		// Has (or had) an elevated role on a site (WordPress.org, BuddyPress.org, bbPress.org, WordCamp.org)
-		$user->has_elevated_role */
+		$user->has_themes
 	) {
 		return true;
 	}

--- a/wporg-two-factor.php
+++ b/wporg-two-factor.php
@@ -226,16 +226,6 @@ function user_requires_2fa( $user ) : bool {
 		return false;
 	}
 
-	// @codeCoverageIgnoreStart
-	if ( ! array_key_exists( 'phpunit_version', $GLOBALS ) ) {
-		// 2FA is opt-in during beta testing.
-		// todo Remove this once we open it to all users.
-		if ( ! is_2fa_beta_tester( $user ) ) {
-			return false;
-		}
-	}
-	// @codeCoverageIgnoreEnd
-
 	$required = false;
 
 	if ( is_special_user( $user->ID ) ) {
@@ -246,6 +236,18 @@ function user_requires_2fa( $user ) : bool {
 		$required = true;
 	}
 
+	// If a user ... they have to have 2FA enabled.
+	if (
+		// Is (or was) a plugin committer
+		$user->has_plugins ||
+		// Has (or had) a live theme
+		$user->has_themes /* ||
+		// Has (or had) an elevated role on a site (WordPress.org, BuddyPress.org, bbPress.org, WordCamp.org)
+		$user->has_elevated_role */
+	) {
+		return true;
+	}
+	
 	return $required;
 }
 


### PR DESCRIPTION
See https://make.wordpress.org/plugins/2024/09/04/upcoming-security-changes-for-plugin-and-theme-authors-on-wordpress-org/

I'm still not 100% sure what effect this will have, as I believe they'll still have access to do many things.

Instead, we should likely focus on expanding the checks at time of action to require them to have 2FA enabled; aka https://github.com/WordPress/wordpress.org/commit/0c9512eb119740ca3510772efa09777c22a9afa1 or https://meta.trac.wordpress.org/ticket/7704 (require 2FA for release confirmation)