### PR TITLE
Remove the border radius from card.

### DIFF
--- a/settings/src/style.scss
+++ b/settings/src/style.scss
@@ -54,6 +54,11 @@ $alert-blue: #72aee6;
 		}
 	}
 
+	.components-card {
+		border-radius: inherit !important;
+		box-shadow: #d9d9d9 0px 0px 0px 1px;
+	}
+
 	.components-card__body p:first-child {
 		margin-top: 0;
 	}


### PR DESCRIPTION
This PR removes the border-radius that was added to the Card component in Gutenberg: https://github.com/WordPress/gutenberg/pull/65053.

## Considerations

I could have used the `isRounded` property to stop the rounding. I decide to do it with CSS instead. Since the `box-shadow` uses `rgba` by default we get some overlap in the corners of the items. Seeing that we'll need that CSS, I decide to enforce it with CSS.

We ultimately need to remove the card component completely. It's not meant for this type of use.