### PR TITLE
Revalidate Modal: Fix issues identified in the initial PR

### DIFF
--- a/revalidation/script.js
+++ b/revalidation/script.js
@@ -139,9 +139,11 @@ window.wp = window.wp || {};
 		// Finally, notify others.
 		( theTriggerEvent?.target || window ).dispatchEvent( new Event( 'reValidationComplete', { bubbles: true } ) );
 
-		// If the last event was a click, throw that again.
+		// If the last event was a click, throw that again, but by re-creating it.
 		if ( theTriggerEvent?.type === 'click' ) {
-			theTriggerEvent.target.dispatchEvent( theTriggerEvent );
+			theTriggerEvent.target.dispatchEvent(
+				new theTriggerEvent.constructor( theTriggerEvent.type, theTriggerEvent )
+			);
 		}
 	};
 

--- a/revalidation/style.css
+++ b/revalidation/style.css
@@ -1,5 +1,6 @@
 dialog.wporg-2fa-revalidate-modal {
 	border-radius: 8px;
+	max-width: 500px;
 }
 dialog.wporg-2fa-revalidate-modal > h1 {
 	margin: unset;


### PR DESCRIPTION
Since #283 was merged I noticed:
 - If you define a long string as the 2FA Message, the "prompt", it expands the modal to accomodate, causing the login UI to look weird.  **Solution:** Define a max with.
 - Clicking buttons which triggered the interstitial wouldn't always submit afterwards. Turns out not all browsers allow you to "re throw" the same event which has already been canceled. **Solution:** Re-create the event and throw it, using the same types and args.