### PR TITLE
WebAuthN: Fix compatibility with latest version of the plugin.

### DIFF
--- a/wporg-two-factor.php
+++ b/wporg-two-factor.php
@@ -76,6 +76,8 @@ function load_webauthn_plugin() {
 		 * The WebAuthn plugin only registers the provider if database schema is up-to-date.
 		 * The schema is stored on a per-network basis, and as we don't allow the WebAuthn plugin to update the schema
 		 * on plugins_loaded, we need to filter the version to match the one that the plugin expects.
+		 *
+		 * @see https://github.com/sjinks/wp-two-factor-provider-webauthn/commit/f243d59ae3a883fe4f4b499ca201ea72f0492f3d
 		 */
 		add_filter( 'default_site_option_2fa-wa-schema-version', static function( $default ) {
 			return 1;

--- a/wporg-two-factor.php
+++ b/wporg-two-factor.php
@@ -69,6 +69,21 @@ function load_webauthn_plugin() {
 		if ( 'wporg_' === $wpdb->base_prefix ) {
 			add_action( 'admin_init', [ $webauthn, 'maybe_update_schema' ] );
 		}
+
+		/**
+		 * Lie to the WebAuthn plugin about the Table schema (if needed).
+		 *
+		 * The WebAuthn plugin only registers the provider if database schema is up-to-date.
+		 * The schema is stored on a per-network basis, and as we don't allow the WebAuthn plugin to update the schema
+		 * on plugins_loaded, we need to filter the version to match the one that the plugin expects.
+		 */
+		add_filter( 'default_site_option_2fa-wa-schema-version', static function( $default ) {
+			if ( 'local' === wp_get_environment_type() ) {
+				return $default;
+			}
+	
+			return 1;
+		} );
 	}
 }
 load_webauthn_plugin();

--- a/wporg-two-factor.php
+++ b/wporg-two-factor.php
@@ -78,10 +78,6 @@ function load_webauthn_plugin() {
 		 * on plugins_loaded, we need to filter the version to match the one that the plugin expects.
 		 */
 		add_filter( 'default_site_option_2fa-wa-schema-version', static function( $default ) {
-			if ( 'local' === wp_get_environment_type() ) {
-				return $default;
-			}
-	
 			return 1;
 		} );
 	}


### PR DESCRIPTION
Fixes  #323

This works around https://github.com/sjinks/wp-two-factor-provider-webauthn/commit/f243d59ae3a883fe4f4b499ca201ea72f0492f3d by ensuring that no matter what network we're running on, that it thinks the database tables exist.

This is needed as we don't run the schema updates, which would set the site option if it wasn't present.