### PR TITLE
WebAuthN: Extend a non-final class

### DIFF
--- a/class-wporg-webauthn-provider.php
+++ b/class-wporg-webauthn-provider.php
@@ -1,7 +1,8 @@
 <?php
 namespace WordPressdotorg\Two_Factor;
-use TwoFactor_Provider_WebAuthn, Two_Factor_Core;
+use Two_Factor_Core;
 use function WordPressdotorg\Two_Factor\{ after_provider_setup, after_provider_deactivated };
+use WildWolf\WordPress\TwoFactorWebAuthn\WebAuthn_Provider as TwoFactor_Provider_WebAuthn; // \TwoFactor_Provider_WebAuthn is marked final.
 
 /**
  * Extends the TwoFactor_Provider_WebAuthn class for WordPress.org needs.


### PR DESCRIPTION
As of version 2.5.5 of the webauthn plugin, many classes are defined as final. This is problematic when we need to extend them.

Thankfully, the final class we're extending is an empty extension of a namespaced class, so we can just extend that.

https://github.com/sjinks/wp-two-factor-provider-webauthn/blob/99102ba6404bccfd55e7f525bc99a481676932dd/inc/class-twofactor-provider-webauthn.php#L5