### PR TITLE
Add application passwords management to security settings

### DIFF
--- a/settings/rest-api.php
+++ b/settings/rest-api.php
@@ -411,6 +411,57 @@ function register_user_fields(): void {
 		]
 	);
 
+	register_rest_field(
+		'user',
+		'application_passwords',
+		[
+			'get_callback' => function( $user ) {
+				$passwords = \WP_Application_Passwords::get_user_application_passwords( $user['id'] );
+
+				return array_values( array_map( function( $password ) {
+					return [
+						'uuid'      => $password['uuid'],
+						'name'      => $password['name'],
+						'created'   => gmdate( 'c', $password['created'] ),
+						'last_used' => $password['last_used'] ? gmdate( 'c', $password['last_used'] ) : false,
+						'last_ip'   => $password['last_ip'] ? $password['last_ip'] : false,
+					];
+				}, $passwords ) );
+			},
+			'schema' => [
+				'type'    => 'array',
+				'context' => [ 'edit' ],
+				'items'   => [
+					'type'       => 'object',
+					'properties' => [
+						'uuid'      => [
+							'type'        => 'string',
+							'description' => 'The unique identifier for the application password.',
+							'format'      => 'uuid',
+						],
+						'name'      => [
+							'type'        => 'string',
+							'description' => 'The name of the application password.',
+						],
+						'created'   => [
+							'type'        => 'string',
+							'description' => 'The date the application password was created, as ISO 8601.',
+							'format'      => 'date-time',
+						],
+						'last_used' => [
+							'type'        => [ 'string', 'boolean' ],
+							'description' => 'The date the application password was last used, as ISO 8601, or false if never used.',
+							'format'      => 'date-time',
+						],
+						'last_ip'   => [
+							'type'        => [ 'string', 'boolean' ],
+							'description' => 'The IP address the application password was last used from, or false if not available.',
+						],
+					],
+				],
+			],
+		]
+	);
 }
 
 /**

--- a/settings/rest-api.php
+++ b/settings/rest-api.php
@@ -423,8 +423,8 @@ function register_user_fields(): void {
 						'uuid'      => $password['uuid'],
 						'name'      => $password['name'],
 						'created'   => gmdate( 'c', $password['created'] ),
-						'last_used' => $password['last_used'] ? gmdate( 'c', $password['last_used'] ) : false,
-						'last_ip'   => $password['last_ip'] ? $password['last_ip'] : false,
+						'last_used' => $password['last_used'] ? gmdate( 'c', $password['last_used'] ) : null,
+						'last_ip'   => $password['last_ip'] ? $password['last_ip'] : null,
 					];
 				}, $passwords ) );
 			},
@@ -449,13 +449,13 @@ function register_user_fields(): void {
 							'format'      => 'date-time',
 						],
 						'last_used' => [
-							'type'        => [ 'string', 'boolean' ],
-							'description' => 'The date the application password was last used, as ISO 8601, or false if never used.',
+							'type'        => [ 'string', 'null' ],
+							'description' => 'The date the application password was last used, as ISO 8601, or null if never used.',
 							'format'      => 'date-time',
 						],
 						'last_ip'   => [
-							'type'        => [ 'string', 'boolean' ],
-							'description' => 'The IP address the application password was last used from, or false if not available.',
+							'type'        => [ 'string', 'null' ],
+							'description' => 'The IP address the application password was last used from, or null if not available.',
 						],
 					],
 				],

--- a/settings/src/components/account-status.js
+++ b/settings/src/components/account-status.js
@@ -30,6 +30,7 @@ export default function AccountStatus() {
 			totpEnabled,
 			backupCodesEnabled,
 			webAuthnEnabled,
+			applicationPasswords,
 		},
 	} = useContext( GlobalContext );
 	const emailStatus = pendingEmail ? 'pending' : 'ok';
@@ -110,6 +111,17 @@ export default function AccountStatus() {
 				/>
 			) : (
 				''
+			) }
+
+			{ applicationPasswords.length > 0 && (
+				<SettingStatusCard
+					screen="application-passwords"
+					status="enabled"
+					headerText="Application passwords"
+					bodyText={ `You have ${ applicationPasswords.length } application password${
+						applicationPasswords.length !== 1 ? 's' : ''
+					}.` }
+				/>
 			) }
 		</div>
 	);

--- a/settings/src/components/application-passwords.js
+++ b/settings/src/components/application-passwords.js
@@ -93,7 +93,9 @@ export default function ApplicationPasswords() {
 						<th>Name</th>
 						<th>Created</th>
 						<th>Last used</th>
-						<th></th>
+						<th>
+							<span className="screen-reader-text">Actions</span>
+						</th>
 					</tr>
 				</thead>
 				<tbody>

--- a/settings/src/components/application-passwords.js
+++ b/settings/src/components/application-passwords.js
@@ -1,0 +1,220 @@
+/**
+ * WordPress dependencies
+ */
+import { Button, Modal, Notice } from '@wordpress/components';
+import { useCallback, useContext, useState } from '@wordpress/element';
+import { Icon, cancelCircleFilled } from '@wordpress/icons';
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Internal dependencies
+ */
+import { GlobalContext } from '../script';
+import { refreshRecord } from '../utilities/common';
+
+/**
+ * Render the Application Passwords setting.
+ */
+export default function ApplicationPasswords() {
+	const {
+		user: { userRecord, applicationPasswords },
+		setGlobalNotice,
+	} = useContext( GlobalContext );
+
+	const [ revokeTarget, setRevokeTarget ] = useState( null );
+	const [ showRevokeAll, setShowRevokeAll ] = useState( false );
+	const [ revoking, setRevoking ] = useState( false );
+	const [ revokeError, setRevokeError ] = useState( '' );
+
+	const handleRevoke = useCallback(
+		async ( path, successMessage, closeModal ) => {
+			setRevoking( true );
+			setRevokeError( '' );
+
+			try {
+				await apiFetch( { path, method: 'DELETE' } );
+			} catch ( error ) {
+				setRevokeError(
+					error?.message ||
+						error?.responseJSON?.data ||
+						'An unexpected error occurred. Please try again.'
+				);
+				setRevoking( false );
+				return;
+			}
+
+			setGlobalNotice( successMessage );
+			closeModal();
+			setRevoking( false );
+
+			try {
+				await refreshRecord( userRecord );
+			} catch {
+				// Revoke succeeded but data refresh failed — a page reload will fix the stale table.
+			}
+		},
+		[ userRecord, setGlobalNotice ]
+	);
+
+	const onConfirmRevoke = useCallback( () => {
+		handleRevoke(
+			`/wp/v2/users/${ userRecord.record.id }/application-passwords/${ revokeTarget.uuid }`,
+			`The application password "${ revokeTarget.name }" has been revoked.`,
+			() => setRevokeTarget( null )
+		);
+	}, [ handleRevoke, revokeTarget, userRecord ] );
+
+	const onConfirmRevokeAll = useCallback( () => {
+		handleRevoke(
+			`/wp/v2/users/${ userRecord.record.id }/application-passwords`,
+			'All application passwords have been revoked.',
+			() => setShowRevokeAll( false )
+		);
+	}, [ handleRevoke, userRecord ] );
+
+	if ( applicationPasswords.length === 0 ) {
+		return (
+			<p className="wporg-2fa__screen-intro">
+				You don&apos;t have any application passwords.
+			</p>
+		);
+	}
+
+	return (
+		<>
+			<p className="wporg-2fa__screen-intro">
+				These passwords let external applications access your account. If you revoke one,
+				the application that uses it will lose access.
+			</p>
+
+			<table className="wporg-2fa__application-passwords-table">
+				<thead>
+					<tr>
+						<th>Name</th>
+						<th>Created</th>
+						<th>Last used</th>
+						<th></th>
+					</tr>
+				</thead>
+				<tbody>
+					{ applicationPasswords.map( ( appPassword ) => (
+						<tr key={ appPassword.uuid }>
+							<td className="wporg-2fa__app-password-name">{ appPassword.name }</td>
+							<td>{ new Date( appPassword.created ).toLocaleDateString() }</td>
+							<td>
+								{ appPassword.last_used
+									? new Date( appPassword.last_used ).toLocaleDateString()
+									: 'Never used' }
+							</td>
+							<td className="wporg-2fa__app-password-actions">
+								<Button
+									variant="link"
+									isDestructive
+									aria-label={ `Revoke ${ appPassword.name }` }
+									onClick={ () => {
+										setRevokeError( '' );
+										setRevokeTarget( appPassword );
+									} }
+								>
+									Revoke
+								</Button>
+							</td>
+						</tr>
+					) ) }
+				</tbody>
+			</table>
+
+			<div className="wporg-2fa__submit-actions">
+				<Button
+					variant="secondary"
+					isDestructive
+					onClick={ () => {
+						setRevokeError( '' );
+						setShowRevokeAll( true );
+					} }
+				>
+					Revoke all application passwords
+				</Button>
+			</div>
+
+			{ revokeTarget && (
+				<ConfirmRevoke
+					appPassword={ revokeTarget }
+					revoking={ revoking }
+					error={ revokeError }
+					onClose={ () => setRevokeTarget( null ) }
+					onConfirm={ onConfirmRevoke }
+				/>
+			) }
+
+			{ showRevokeAll && (
+				<ConfirmRevoke
+					revoking={ revoking }
+					error={ revokeError }
+					onClose={ () => setShowRevokeAll( false ) }
+					onConfirm={ onConfirmRevokeAll }
+				/>
+			) }
+		</>
+	);
+}
+
+/**
+ * Prompt the user to confirm they want to revoke application password(s).
+ *
+ * When `appPassword` is provided, confirms revoking that single password.
+ * Otherwise, confirms revoking all passwords.
+ *
+ * @param {Object}   props
+ * @param {Object}   [props.appPassword] The application password to revoke. Omit for all.
+ * @param {boolean}  props.revoking      Whether a revoke request is in progress.
+ * @param {string}   props.error         Error message from a failed revoke attempt.
+ * @param {Function} props.onClose       Callback to close the modal without revoking.
+ * @param {Function} props.onConfirm     Callback to confirm and execute the revoke.
+ */
+function ConfirmRevoke( { appPassword, revoking, error, onClose, onConfirm } ) {
+	const isSingle = !! appPassword;
+
+	return (
+		<Modal
+			title={ isSingle ? 'Revoke application password' : 'Revoke all application passwords' }
+			className="wporg-2fa__confirm-revoke-app-password"
+			onRequestClose={ onClose }
+		>
+			<p className="wporg-2fa__screen-intro">
+				{ isSingle ? (
+					<>
+						Are you sure you want to revoke the application password &ldquo;
+						{ appPassword.name }&rdquo;? Any application using it will no longer be able
+						to access your account.
+					</>
+				) : (
+					'Are you sure you want to revoke all application passwords? Any applications using them will no longer be able to access your account.'
+				) }
+			</p>
+
+			<div className="wporg-2fa__submit-actions">
+				<Button
+					variant="primary"
+					isDestructive
+					isBusy={ revoking }
+					disabled={ revoking }
+					onClick={ onConfirm }
+				>
+					{ isSingle ? 'Revoke password' : 'Revoke all passwords' }
+				</Button>
+
+				<Button variant="secondary" onClick={ onClose }>
+					Cancel
+				</Button>
+			</div>
+
+			{ error && (
+				<Notice status="error" isDismissible={ false }>
+					<Icon icon={ cancelCircleFilled } />
+					{ error }
+				</Notice>
+			) }
+		</Modal>
+	);
+}

--- a/settings/src/components/application-passwords.scss
+++ b/settings/src/components/application-passwords.scss
@@ -1,0 +1,47 @@
+@use '~@wordpress/base-styles/colors' as *;
+
+.wporg-2fa__application-passwords,
+.bbp-single-user .wporg-2fa__application-passwords {
+	.wporg-2fa__application-passwords-table {
+		width: 100%;
+		border-collapse: collapse;
+
+		th {
+			text-align: left;
+			font-size: 12px;
+			font-weight: 600;
+			text-transform: uppercase;
+			letter-spacing: 0.5px;
+			color: $gray-700;
+			padding: 8px 12px 8px 0;
+			border-bottom: 2px solid $gray-300;
+		}
+
+		td {
+			padding: 16px 12px 16px 0;
+			border-bottom: 1px solid $gray-300;
+			font-size: 13px;
+			vertical-align: middle;
+		}
+
+		tr:last-child td {
+			border-bottom: none;
+		}
+
+		.wporg-2fa__app-password-name {
+			font-weight: 500;
+		}
+
+		.wporg-2fa__app-password-actions {
+			text-align: right;
+			padding-right: 0;
+		}
+	}
+}
+
+.components-modal__frame.wporg-2fa__confirm-revoke-app-password,
+.components-modal__frame.wporg-2fa__confirm-revoke-all-app-passwords {
+	.components-notice.is-error {
+		margin-top: 18px;
+	}
+}

--- a/settings/src/components/application-passwords.scss
+++ b/settings/src/components/application-passwords.scss
@@ -39,8 +39,7 @@
 	}
 }
 
-.components-modal__frame.wporg-2fa__confirm-revoke-app-password,
-.components-modal__frame.wporg-2fa__confirm-revoke-all-app-passwords {
+.components-modal__frame.wporg-2fa__confirm-revoke-app-password {
 	.components-notice.is-error {
 		margin-top: 18px;
 	}

--- a/settings/src/components/settings.js
+++ b/settings/src/components/settings.js
@@ -73,7 +73,7 @@ export default function Settings() {
 			component: <SVNPassword />,
 		},
 		'application-passwords': {
-			title: 'Application Passwords',
+			title: 'Application passwords',
 			component: <ApplicationPasswords />,
 		},
 	};

--- a/settings/src/components/settings.js
+++ b/settings/src/components/settings.js
@@ -14,6 +14,7 @@ import TOTP from './totp';
 import WebAuthn from './webauthn/webauthn';
 import BackupCodes from './backup-codes';
 import SVNPassword from './svn-password';
+import ApplicationPasswords from './application-passwords';
 
 import { GlobalContext } from '../script';
 
@@ -70,6 +71,10 @@ export default function Settings() {
 		'svn-password': {
 			title: 'SVN credentials',
 			component: <SVNPassword />,
+		},
+		'application-passwords': {
+			title: 'Application Passwords',
+			component: <ApplicationPasswords />,
 		},
 	};
 

--- a/settings/src/hooks/useUser.js
+++ b/settings/src/hooks/useUser.js
@@ -18,6 +18,9 @@ export function useUser( userId ) {
 	const totpEnabled = availableProviders.includes( 'Two_Factor_Totp' );
 	const backupCodesEnabled = availableProviders.includes( 'Two_Factor_Backup_Codes' );
 	const webAuthnEnabled = availableProviders.includes( 'TwoFactor_Provider_WebAuthn' );
+	const applicationPasswords = Array.isArray( userRecord.record?.application_passwords )
+		? userRecord.record.application_passwords
+		: [];
 	const hasPrimaryProvider = totpEnabled || webAuthnEnabled;
 
 	return {
@@ -29,5 +32,6 @@ export function useUser( userId ) {
 		backupCodesEnabled,
 		webAuthnEnabled,
 		backupCodesRemaining,
+		applicationPasswords,
 	};
 }

--- a/settings/src/hooks/useUser.js
+++ b/settings/src/hooks/useUser.js
@@ -18,9 +18,7 @@ export function useUser( userId ) {
 	const totpEnabled = availableProviders.includes( 'Two_Factor_Totp' );
 	const backupCodesEnabled = availableProviders.includes( 'Two_Factor_Backup_Codes' );
 	const webAuthnEnabled = availableProviders.includes( 'TwoFactor_Provider_WebAuthn' );
-	const applicationPasswords = Array.isArray( userRecord.record?.application_passwords )
-		? userRecord.record.application_passwords
-		: [];
+	const applicationPasswords = userRecord.record?.application_passwords ?? [];
 	const hasPrimaryProvider = totpEnabled || webAuthnEnabled;
 
 	return {

--- a/settings/src/script.js
+++ b/settings/src/script.js
@@ -67,7 +67,13 @@ function Main( { userId, isOnboarding } ) {
 	const [ screen, setScreen ] = useState( initialScreen === null ? 'home' : initialScreen );
 
 	// The screens where a recent two factor challenge is required.
-	const twoFactorRequiredScreens = [ 'webauthn', 'totp', 'backup-codes', 'svn-password' ];
+	const twoFactorRequiredScreens = [
+		'webauthn',
+		'totp',
+		'backup-codes',
+		'svn-password',
+		'application-passwords',
+	];
 
 	// Listen for back/forward button clicks.
 	useEffect( () => {

--- a/settings/src/style.scss
+++ b/settings/src/style.scss
@@ -14,3 +14,4 @@
 @use "components/first-time/first-time";
 @use "components/first-time/setup-progress-bar";
 @use "components/svn-password";
+@use "components/application-passwords";

--- a/settings/src/tests/application-passwords/application-passwords.test.js
+++ b/settings/src/tests/application-passwords/application-passwords.test.js
@@ -35,8 +35,8 @@ const mockAppPasswords = [
 		uuid: 'uuid-2',
 		name: 'Jetpack',
 		created: '2026-02-20T08:00:00+00:00',
-		last_used: false,
-		last_ip: false,
+		last_used: null,
+		last_ip: null,
 	},
 ];
 

--- a/settings/src/tests/application-passwords/application-passwords.test.js
+++ b/settings/src/tests/application-passwords/application-passwords.test.js
@@ -1,0 +1,223 @@
+/* global jest, describe, beforeEach, afterEach, it, expect */
+
+/**
+ * External dependencies
+ */
+import { render, fireEvent, waitFor } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import { useContext } from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Local dependencies
+ */
+import ApplicationPasswords from '../../components/application-passwords';
+
+jest.mock( '@wordpress/element', () => ( {
+	...jest.requireActual( '@wordpress/element' ),
+	useContext: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/api-fetch' );
+
+const mockAppPasswords = [
+	{
+		uuid: 'uuid-1',
+		name: 'WordPress MCP',
+		created: '2026-01-15T10:30:00+00:00',
+		last_used: '2026-03-10T14:22:00+00:00',
+		last_ip: '192.168.1.1',
+	},
+	{
+		uuid: 'uuid-2',
+		name: 'Jetpack',
+		created: '2026-02-20T08:00:00+00:00',
+		last_used: false,
+		last_ip: false,
+	},
+];
+
+const createMockContext = ( appPasswords = mockAppPasswords ) => ( {
+	user: {
+		userRecord: {
+			record: { id: 1 },
+			edit: jest.fn(),
+			save: jest.fn().mockResolvedValue( true ),
+		},
+		applicationPasswords: appPasswords,
+	},
+	setGlobalNotice: jest.fn(),
+} );
+
+describe( 'ApplicationPasswords', () => {
+	let mockContext;
+
+	beforeEach( () => {
+		mockContext = createMockContext();
+		useContext.mockReturnValue( mockContext );
+		apiFetch.mockResolvedValue( {} );
+	} );
+
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	describe( 'Empty state', () => {
+		it( 'should show empty message when no application passwords exist', () => {
+			mockContext = createMockContext( [] );
+			useContext.mockReturnValue( mockContext );
+
+			const { getByText } = render( <ApplicationPasswords /> );
+
+			expect( getByText( /don't have any application passwords/ ) ).toBeTruthy();
+		} );
+
+		it( 'should not render a table when no application passwords exist', () => {
+			mockContext = createMockContext( [] );
+			useContext.mockReturnValue( mockContext );
+
+			const { queryByRole } = render( <ApplicationPasswords /> );
+
+			expect( queryByRole( 'table' ) ).toBeNull();
+		} );
+	} );
+
+	describe( 'Table display', () => {
+		it( 'should render a table with application passwords', () => {
+			const { getByRole } = render( <ApplicationPasswords /> );
+
+			expect( getByRole( 'table' ) ).toBeTruthy();
+		} );
+
+		it( 'should display application password names', () => {
+			const { getByText } = render( <ApplicationPasswords /> );
+
+			expect( getByText( 'WordPress MCP' ) ).toBeTruthy();
+			expect( getByText( 'Jetpack' ) ).toBeTruthy();
+		} );
+
+		it( 'should display "Never used" for passwords that have not been used', () => {
+			const { getByText } = render( <ApplicationPasswords /> );
+
+			expect( getByText( 'Never used' ) ).toBeTruthy();
+		} );
+
+		it( 'should render a revoke button for each password', () => {
+			const { getAllByText } = render( <ApplicationPasswords /> );
+
+			expect( getAllByText( 'Revoke' ) ).toHaveLength( 2 );
+		} );
+
+		it( 'should render the revoke all button', () => {
+			const { getByText } = render( <ApplicationPasswords /> );
+
+			expect( getByText( 'Revoke all application passwords' ) ).toBeTruthy();
+		} );
+	} );
+
+	describe( 'Revoke single', () => {
+		it( 'should show confirmation modal when clicking revoke', () => {
+			const { getAllByText, getByText } = render( <ApplicationPasswords /> );
+
+			fireEvent.click( getAllByText( 'Revoke' )[ 0 ] );
+
+			expect( getByText( 'Revoke password' ) ).toBeTruthy();
+			expect( getByText( /Are you sure you want to revoke/ ) ).toBeTruthy();
+		} );
+
+		it( 'should call the correct API endpoint when confirming revoke', async () => {
+			const { getAllByText, getByText } = render( <ApplicationPasswords /> );
+
+			fireEvent.click( getAllByText( 'Revoke' )[ 0 ] );
+			fireEvent.click( getByText( 'Revoke password' ) );
+
+			await waitFor( () => {
+				expect( apiFetch ).toHaveBeenCalledWith( {
+					path: '/wp/v2/users/1/application-passwords/uuid-1',
+					method: 'DELETE',
+				} );
+			} );
+		} );
+
+		it( 'should show success notice after revoking', async () => {
+			const { getAllByText, getByText } = render( <ApplicationPasswords /> );
+
+			fireEvent.click( getAllByText( 'Revoke' )[ 0 ] );
+			fireEvent.click( getByText( 'Revoke password' ) );
+
+			await waitFor( () => {
+				expect( mockContext.setGlobalNotice ).toHaveBeenCalledWith(
+					'The application password "WordPress MCP" has been revoked.'
+				);
+			} );
+		} );
+
+		it( 'should close modal when clicking cancel', () => {
+			const { getAllByText, getByText, queryByText } = render( <ApplicationPasswords /> );
+
+			fireEvent.click( getAllByText( 'Revoke' )[ 0 ] );
+			expect( getByText( 'Revoke password' ) ).toBeTruthy();
+
+			fireEvent.click( getByText( 'Cancel' ) );
+			expect( queryByText( 'Revoke password' ) ).toBeNull();
+		} );
+	} );
+
+	describe( 'Revoke all', () => {
+		it( 'should show confirmation modal when clicking revoke all', () => {
+			const { getByText } = render( <ApplicationPasswords /> );
+
+			fireEvent.click( getByText( 'Revoke all application passwords' ) );
+
+			expect( getByText( /revoke all application passwords\?/i ) ).toBeTruthy();
+			expect( getByText( 'Revoke all passwords' ) ).toBeTruthy();
+		} );
+
+		it( 'should call the correct API endpoint when confirming revoke all', async () => {
+			const { getByText } = render( <ApplicationPasswords /> );
+
+			fireEvent.click( getByText( 'Revoke all application passwords' ) );
+			fireEvent.click( getByText( 'Revoke all passwords' ) );
+
+			await waitFor( () => {
+				expect( apiFetch ).toHaveBeenCalledWith( {
+					path: '/wp/v2/users/1/application-passwords',
+					method: 'DELETE',
+				} );
+			} );
+		} );
+
+		it( 'should show success notice after revoking all', async () => {
+			const { getByText } = render( <ApplicationPasswords /> );
+
+			fireEvent.click( getByText( 'Revoke all application passwords' ) );
+			fireEvent.click( getByText( 'Revoke all passwords' ) );
+
+			await waitFor( () => {
+				expect( mockContext.setGlobalNotice ).toHaveBeenCalledWith(
+					'All application passwords have been revoked.'
+				);
+			} );
+		} );
+	} );
+
+	describe( 'Error handling', () => {
+		it( 'should display error in modal when revoke fails', async () => {
+			apiFetch.mockRejectedValue( { message: 'Something went wrong' } );
+
+			const { getAllByText, getByText, queryAllByText } = render( <ApplicationPasswords /> );
+
+			fireEvent.click( getAllByText( 'Revoke' )[ 0 ] );
+			fireEvent.click( getByText( 'Revoke password' ) );
+
+			await waitFor( () => {
+				expect( queryAllByText( 'Something went wrong' ).length ).toBeGreaterThanOrEqual(
+					1
+				);
+			} );
+		} );
+	} );
+} );

--- a/tests/settings/test-application-passwords.php
+++ b/tests/settings/test-application-passwords.php
@@ -60,7 +60,7 @@ class Test_WPorg_Two_Factor_Application_Passwords extends WP_UnitTestCase {
 	public function test_application_passwords_field_returns_expected_data() : void {
 		wp_set_current_user( self::$privileged_user->ID, self::$privileged_user->user_login );
 
-		$created = WP_Application_Passwords::create_new_application_password(
+		WP_Application_Passwords::create_new_application_password(
 			self::$privileged_user->ID,
 			array( 'name' => 'Test App' )
 		);
@@ -80,8 +80,8 @@ class Test_WPorg_Two_Factor_Application_Passwords extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'created', $password );
 		$this->assertArrayHasKey( 'last_used', $password );
 		$this->assertArrayHasKey( 'last_ip', $password );
-		$this->assertFalse( $password['last_used'] );
-		$this->assertFalse( $password['last_ip'] );
+		$this->assertNull( $password['last_used'] );
+		$this->assertNull( $password['last_ip'] );
 	}
 
 	/**

--- a/tests/settings/test-application-passwords.php
+++ b/tests/settings/test-application-passwords.php
@@ -1,0 +1,180 @@
+<?php
+
+defined( 'WPINC' ) || die();
+
+class Test_WPorg_Two_Factor_Application_Passwords extends WP_UnitTestCase {
+	protected static WP_User $privileged_user;
+	protected static WP_User $regular_user;
+
+	/**
+	 * Initialize things when class loads.
+	 */
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) : void {
+		self::$privileged_user = $factory->user->create_and_get( array( 'user_login' => 'app_pass_privileged' ) );
+		self::$regular_user   = $factory->user->create_and_get( array(
+			'user_login' => 'app_pass_regular',
+			'role'       => 'contributor',
+		) );
+	}
+
+	/**
+	 * Clean up application passwords after each test.
+	 */
+	public function tear_down() : void {
+		WP_Application_Passwords::delete_all_application_passwords( self::$privileged_user->ID );
+		WP_Application_Passwords::delete_all_application_passwords( self::$regular_user->ID );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Perform an internal API request.
+	 */
+	protected function api_request( string $method, string $endpoint, array $params = [] ) : array {
+		$request = new WP_REST_Request( $method, $endpoint );
+		$request->set_query_params( $params );
+
+		$response = rest_do_request( $request );
+		return rest_get_server()->response_to_data( $response, false );
+	}
+
+	/**
+	 * @covers WordPressdotorg\Two_Factor\register_user_fields
+	 */
+	public function test_application_passwords_field_returns_empty_array_when_none_exist() : void {
+		wp_set_current_user( self::$privileged_user->ID, self::$privileged_user->user_login );
+
+		$actual = $this->api_request(
+			'GET',
+			'/wp/v2/users/' . self::$privileged_user->ID,
+			array( 'context' => 'edit' )
+		);
+
+		$this->assertArrayHasKey( 'application_passwords', $actual );
+		$this->assertSame( array(), $actual['application_passwords'] );
+	}
+
+	/**
+	 * @covers WordPressdotorg\Two_Factor\register_user_fields
+	 */
+	public function test_application_passwords_field_returns_expected_data() : void {
+		wp_set_current_user( self::$privileged_user->ID, self::$privileged_user->user_login );
+
+		$created = WP_Application_Passwords::create_new_application_password(
+			self::$privileged_user->ID,
+			array( 'name' => 'Test App' )
+		);
+
+		$actual = $this->api_request(
+			'GET',
+			'/wp/v2/users/' . self::$privileged_user->ID,
+			array( 'context' => 'edit' )
+		);
+
+		$this->assertArrayHasKey( 'application_passwords', $actual );
+		$this->assertCount( 1, $actual['application_passwords'] );
+
+		$password = $actual['application_passwords'][0];
+		$this->assertSame( 'Test App', $password['name'] );
+		$this->assertArrayHasKey( 'uuid', $password );
+		$this->assertArrayHasKey( 'created', $password );
+		$this->assertArrayHasKey( 'last_used', $password );
+		$this->assertArrayHasKey( 'last_ip', $password );
+		$this->assertFalse( $password['last_used'] );
+		$this->assertFalse( $password['last_ip'] );
+	}
+
+	/**
+	 * @covers WordPressdotorg\Two_Factor\register_user_fields
+	 */
+	public function test_application_passwords_field_returns_multiple_passwords() : void {
+		wp_set_current_user( self::$privileged_user->ID, self::$privileged_user->user_login );
+
+		WP_Application_Passwords::create_new_application_password(
+			self::$privileged_user->ID,
+			array( 'name' => 'App One' )
+		);
+		WP_Application_Passwords::create_new_application_password(
+			self::$privileged_user->ID,
+			array( 'name' => 'App Two' )
+		);
+
+		$actual = $this->api_request(
+			'GET',
+			'/wp/v2/users/' . self::$privileged_user->ID,
+			array( 'context' => 'edit' )
+		);
+
+		$this->assertCount( 2, $actual['application_passwords'] );
+
+		$names = array_column( $actual['application_passwords'], 'name' );
+		$this->assertContains( 'App One', $names );
+		$this->assertContains( 'App Two', $names );
+	}
+
+	/**
+	 * @covers WordPressdotorg\Two_Factor\register_user_fields
+	 */
+	public function test_application_passwords_field_returns_iso8601_created_date() : void {
+		wp_set_current_user( self::$privileged_user->ID, self::$privileged_user->user_login );
+
+		WP_Application_Passwords::create_new_application_password(
+			self::$privileged_user->ID,
+			array( 'name' => 'Date Test App' )
+		);
+
+		$actual = $this->api_request(
+			'GET',
+			'/wp/v2/users/' . self::$privileged_user->ID,
+			array( 'context' => 'edit' )
+		);
+
+		$password = $actual['application_passwords'][0];
+
+		// Verify the created date is a valid ISO 8601 string.
+		$this->assertNotFalse( strtotime( $password['created'] ) );
+	}
+
+	/**
+	 * @covers WordPressdotorg\Two_Factor\register_user_fields
+	 */
+	public function test_application_passwords_field_not_in_view_context() : void {
+		wp_set_current_user( self::$privileged_user->ID, self::$privileged_user->user_login );
+
+		WP_Application_Passwords::create_new_application_password(
+			self::$privileged_user->ID,
+			array( 'name' => 'Context Test App' )
+		);
+
+		$actual = $this->api_request(
+			'GET',
+			'/wp/v2/users/' . self::$privileged_user->ID,
+			array( 'context' => 'view' )
+		);
+
+		$this->assertArrayNotHasKey( 'application_passwords', $actual );
+	}
+
+	/**
+	 * @covers WordPressdotorg\Two_Factor\register_user_fields
+	 */
+	public function test_application_passwords_field_excludes_sensitive_data() : void {
+		wp_set_current_user( self::$privileged_user->ID, self::$privileged_user->user_login );
+
+		WP_Application_Passwords::create_new_application_password(
+			self::$privileged_user->ID,
+			array( 'name' => 'Sensitive Test' )
+		);
+
+		$actual = $this->api_request(
+			'GET',
+			'/wp/v2/users/' . self::$privileged_user->ID,
+			array( 'context' => 'edit' )
+		);
+
+		$password = $actual['application_passwords'][0];
+		$allowed_keys = array( 'uuid', 'name', 'created', 'last_used', 'last_ip' );
+
+		$this->assertSame( $allowed_keys, array_keys( $password ) );
+	}
+}


### PR DESCRIPTION
## Summary

- Adds an "Application passwords" card to the security settings home screen, visible only when the user has app passwords
- Detail screen shows a table of all application passwords with name, created date, and last used date
- Users can revoke individual passwords or all at once, with confirmation modals
- Uses WordPress core REST endpoints for DELETE operations; adds a custom REST field for reading
- Requires 2FA revalidation to access the screen

<img width="1001" height="616" alt="Screenshot 2026-03-11 at 8 45 30 AM" src="https://github.com/user-attachments/assets/7151f4fe-1732-463d-9fae-74eb60cb3b25" />

<img width="1001" height="414" alt="Screenshot 2026-03-11 at 8 45 19 AM" src="https://github.com/user-attachments/assets/2ffac5ab-5e79-49a9-a332-329fea259f55" />



## Test plan

- [ ] Create application passwords via WP-CLI: `npx wp-env run cli wp user application-password create 1 "Test App"`
- [ ] Verify the card appears on the home screen at `/users/admin/edit/account/`
- [ ] Verify the card does NOT appear when there are no application passwords
- [ ] Click into the detail screen and verify the table displays correctly
- [ ] Revoke a single password and verify the confirmation modal and success notice
- [ ] Revoke all passwords and verify the confirmation modal and success notice
- [ ] Verify the card disappears from the home screen after all passwords are revoked
- [x] Run `npm test` (PHP) and `npm run test:js` (JS) — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)