### PR TITLE
Show last IP address in the application passwords table

### DIFF
--- a/settings/src/components/application-passwords.js
+++ b/settings/src/components/application-passwords.js
@@ -93,6 +93,7 @@ export default function ApplicationPasswords() {
 						<th>Name</th>
 						<th>Created</th>
 						<th>Last used</th>
+						<th>Last IP</th>
 						<th>
 							<span className="screen-reader-text">Actions</span>
 						</th>
@@ -108,6 +109,7 @@ export default function ApplicationPasswords() {
 									? new Date( appPassword.last_used ).toLocaleDateString()
 									: 'Never used' }
 							</td>
+							<td>{ appPassword.last_ip || '—' }</td>
 							<td className="wporg-2fa__app-password-actions">
 								<Button
 									variant="link"

--- a/settings/src/tests/application-passwords/application-passwords.test.js
+++ b/settings/src/tests/application-passwords/application-passwords.test.js
@@ -105,6 +105,18 @@ describe( 'ApplicationPasswords', () => {
 			expect( getByText( 'Never used' ) ).toBeTruthy();
 		} );
 
+		it( 'should display the last IP when available', () => {
+			const { getByText } = render( <ApplicationPasswords /> );
+
+			expect( getByText( '192.168.1.1' ) ).toBeTruthy();
+		} );
+
+		it( 'should display an em dash when last IP is not available', () => {
+			const { getAllByText } = render( <ApplicationPasswords /> );
+
+			expect( getAllByText( '—' ).length ).toBeGreaterThanOrEqual( 1 );
+		} );
+
 		it( 'should render a revoke button for each password', () => {
 			const { getAllByText } = render( <ApplicationPasswords /> );
 


### PR DESCRIPTION
## Summary
- Add a "Last IP" column to the application passwords table, matching WordPress core's `WP_Application_Passwords_List_Table`
- The REST API was already returning `last_ip` but the UI wasn't displaying it
- Shows an em dash when no IP is available (consistent with core)

## Test plan
- [ ] Verify the "Last IP" column appears in the application passwords table
- [ ] Verify IPs are displayed for passwords that have been used
- [ ] Verify an em dash is shown for passwords without an IP
- [ ] JS unit tests pass (`npm run test:js`)