### PR TITLE
Build: Use the merger's identity for build commits

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,8 +39,8 @@ jobs:
 
             - name: Commit and push
               run: |
-                  git config user.name "GitHub Actions"
-                  git config user.email "actions@github.com"
+                  git config user.name "$(git log -1 --format='%an' ${{ github.sha }})"
+                  git config user.email "$(git log -1 --format='%ae' ${{ github.sha }})"
                   git add * --force
                   git commit -m "Build: ${{ github.sha }}" --allow-empty
                   git push --force origin HEAD:build


### PR DESCRIPTION
## Summary

- The switch from `actions-js/push` to native git commands in b51590f hardcoded the build commit author as `GitHub Actions <actions@github.com>`
- Pull the author name and email from the triggering commit (`github.sha`) instead, so build commits show who merged the PR — matching the previous behavior

## Test plan

- [ ] Merge this PR and verify the resulting build branch commit shows the merger's name/email, not `GitHub Actions`

🤖 Generated with [Claude Code](https://claude.com/claude-code)