### PR TITLE
Fix application password revocation on multisite for non-members

### DIFF
--- a/settings/rest-api.php
+++ b/settings/rest-api.php
@@ -10,6 +10,7 @@ defined( 'WPINC' ) || die();
 
 add_action( 'rest_api_init', __NAMESPACE__ . '\register_rest_routes' );
 add_action( 'rest_api_init', __NAMESPACE__ . '\register_user_fields' );
+add_filter( 'rest_pre_dispatch', __NAMESPACE__ . '\allow_application_password_management', 10, 3 );
 add_filter( 'rest_pre_insert_user', __NAMESPACE__ . '\require_email_confirmation', 10, 2 );
 add_filter( 'bp_before_profile_edit_content', __NAMESPACE__ . '\process_email_change_confirmation' );
 add_filter( 'admin_page_access_denied', __NAMESPACE__ . '\redirect_wpadmin_profile' );
@@ -464,6 +465,69 @@ function register_user_fields(): void {
 			],
 		]
 	);
+}
+
+/**
+ * Allow users to manage their own application passwords on multisite, even if
+ * they are not a member of the current blog.
+ *
+ * Core's WP_REST_Application_Passwords_Controller::get_user() checks
+ * is_user_member_of_blog() and returns a 404 for non-members. On WordPress.org,
+ * most users aren't members of every blog (e.g., profiles.wordpress.org), so
+ * application password operations like revoke fail.
+ *
+ * This works by filtering `get_user_metadata` to return a minimal capabilities
+ * array for the current user's blog capabilities key, which makes
+ * is_user_member_of_blog() return true.
+ *
+ * @param mixed            $result  Response to replace the requested version with. Can be anything
+ *                                  a normal endpoint can return, or null to not hijack the request.
+ * @param \WP_REST_Server  $server  Server instance.
+ * @param \WP_REST_Request $request Request used to generate the response.
+ * @return mixed Unmodified $result.
+ */
+function allow_application_password_management( $result, $server, $request ) {
+	if ( ! is_multisite() ) {
+		return $result;
+	}
+
+	if ( ! preg_match( '#^/wp/v2/users/\d+/application-passwords#', $request->get_route() ) ) {
+		return $result;
+	}
+
+	$current_user_id = get_current_user_id();
+	if ( ! $current_user_id ) {
+		return $result;
+	}
+
+	add_filter(
+		'get_user_metadata',
+		function ( $check, $user_id, $meta_key ) use ( $current_user_id ) {
+			global $wpdb;
+
+			if ( $user_id !== $current_user_id ) {
+				return $check;
+			}
+
+			$blog_id          = get_current_blog_id();
+			$capabilities_key = $wpdb->base_prefix;
+			if ( 1 !== $blog_id ) {
+				$capabilities_key .= $blog_id . '_';
+			}
+			$capabilities_key .= 'capabilities';
+
+			if ( $meta_key !== $capabilities_key ) {
+				return $check;
+			}
+
+			// Return a nested array: get_metadata() unwraps one level when $single is true.
+			return array( array( 'subscriber' => true ) );
+		},
+		10,
+		3
+	);
+
+	return $result;
 }
 
 /**

--- a/settings/rest-api.php
+++ b/settings/rest-api.php
@@ -476,10 +476,6 @@ function register_user_fields(): void {
  * most users aren't members of every blog (e.g., profiles.wordpress.org), so
  * application password operations like revoke fail.
  *
- * This works by filtering `get_user_metadata` to return a minimal capabilities
- * array for the current user's blog capabilities key, which makes
- * is_user_member_of_blog() return true.
- *
  * @param mixed            $result  Response to replace the requested version with. Can be anything
  *                                  a normal endpoint can return, or null to not hijack the request.
  * @param \WP_REST_Server  $server  Server instance.
@@ -499,7 +495,7 @@ function allow_application_password_management( $result, $server, $request ) {
 		return $result;
 	}
 
-	add_filter( 'get_user_metadata', __NAMESPACE__ . '\spoof_blog_membership_for_current_user', 10, 3 );
+	add_filter( 'get_user_metadata', __NAMESPACE__ . '\treat_as_member_of_blog', 10, 3 );
 
 	return $result;
 }
@@ -518,21 +514,14 @@ function allow_application_password_management( $result, $server, $request ) {
  * @param string $meta_key The meta key.
  * @return mixed A capabilities array for the current user's blog capabilities key, or $check unchanged.
  */
-function spoof_blog_membership_for_current_user( $check, $user_id, $meta_key ) {
+function treat_as_member_of_blog( $check, $user_id, $meta_key ) {
 	global $wpdb;
 
 	if ( $user_id !== get_current_user_id() ) {
 		return $check;
 	}
 
-	$blog_id          = get_current_blog_id();
-	$capabilities_key = $wpdb->base_prefix;
-	if ( 1 !== $blog_id ) {
-		$capabilities_key .= $blog_id . '_';
-	}
-	$capabilities_key .= 'capabilities';
-
-	if ( $meta_key !== $capabilities_key ) {
+	if ( $meta_key !== $wpdb->get_blog_prefix() . 'capabilities' ) {
 		return $check;
 	}
 

--- a/settings/rest-api.php
+++ b/settings/rest-api.php
@@ -496,10 +496,14 @@ function allow_application_password_management( $result, $server, $request ) {
 	}
 
 	add_filter( 'get_user_metadata', __NAMESPACE__ . '\treat_as_member_of_blog', 10, 3 );
-	add_filter( 'rest_post_dispatch', function( $response ) {
-		remove_filter( 'get_user_metadata', __NAMESPACE__ . '\treat_as_member_of_blog', 10 );
-		return $response;
-	} );
+	add_filter(
+		'rest_post_dispatch',
+		function ( $response ) {
+			remove_filter( 'get_user_metadata', __NAMESPACE__ . '\treat_as_member_of_blog' );
+
+			return $response;
+		}
+	);
 
 	return $result;
 }
@@ -521,7 +525,7 @@ function allow_application_password_management( $result, $server, $request ) {
 function treat_as_member_of_blog( $check, $user_id, $meta_key ) {
 	global $wpdb;
 
-	if ( $user_id !== get_current_user_id() ) {
+	if ( get_current_user_id() !== $user_id ) {
 		return $check;
 	}
 

--- a/settings/rest-api.php
+++ b/settings/rest-api.php
@@ -495,39 +495,49 @@ function allow_application_password_management( $result, $server, $request ) {
 		return $result;
 	}
 
-	$current_user_id = get_current_user_id();
-	if ( ! $current_user_id ) {
+	if ( ! get_current_user_id() ) {
 		return $result;
 	}
 
-	add_filter(
-		'get_user_metadata',
-		function ( $check, $user_id, $meta_key ) use ( $current_user_id ) {
-			global $wpdb;
-
-			if ( $user_id !== $current_user_id ) {
-				return $check;
-			}
-
-			$blog_id          = get_current_blog_id();
-			$capabilities_key = $wpdb->base_prefix;
-			if ( 1 !== $blog_id ) {
-				$capabilities_key .= $blog_id . '_';
-			}
-			$capabilities_key .= 'capabilities';
-
-			if ( $meta_key !== $capabilities_key ) {
-				return $check;
-			}
-
-			// Return a nested array: get_metadata() unwraps one level when $single is true.
-			return array( array( 'subscriber' => true ) );
-		},
-		10,
-		3
-	);
+	add_filter( 'get_user_metadata', __NAMESPACE__ . '\spoof_blog_membership_for_current_user', 10, 3 );
 
 	return $result;
+}
+
+/**
+ * Make is_user_member_of_blog() return true for the current user.
+ *
+ * When get_user_meta() is called with the current blog's capabilities key for the
+ * current user, return a minimal capabilities array so is_user_member_of_blog()
+ * sees an array and returns true.
+ *
+ * @see allow_application_password_management()
+ *
+ * @param mixed  $check    The value to return instead of the user meta value. Default null.
+ * @param int    $user_id  The user ID.
+ * @param string $meta_key The meta key.
+ * @return mixed A capabilities array for the current user's blog capabilities key, or $check unchanged.
+ */
+function spoof_blog_membership_for_current_user( $check, $user_id, $meta_key ) {
+	global $wpdb;
+
+	if ( $user_id !== get_current_user_id() ) {
+		return $check;
+	}
+
+	$blog_id          = get_current_blog_id();
+	$capabilities_key = $wpdb->base_prefix;
+	if ( 1 !== $blog_id ) {
+		$capabilities_key .= $blog_id . '_';
+	}
+	$capabilities_key .= 'capabilities';
+
+	if ( $meta_key !== $capabilities_key ) {
+		return $check;
+	}
+
+	// Return a nested array: get_metadata() unwraps one level when $single is true.
+	return array( array( 'subscriber' => true ) );
 }
 
 /**

--- a/settings/rest-api.php
+++ b/settings/rest-api.php
@@ -496,6 +496,10 @@ function allow_application_password_management( $result, $server, $request ) {
 	}
 
 	add_filter( 'get_user_metadata', __NAMESPACE__ . '\treat_as_member_of_blog', 10, 3 );
+	add_filter( 'rest_post_dispatch', function( $response ) {
+		remove_filter( 'get_user_metadata', __NAMESPACE__ . '\treat_as_member_of_blog', 10 );
+		return $response;
+	} );
 
 	return $result;
 }
@@ -526,7 +530,8 @@ function treat_as_member_of_blog( $check, $user_id, $meta_key ) {
 	}
 
 	// Return a nested array: get_metadata() unwraps one level when $single is true.
-	return array( array( 'subscriber' => true ) );
+	// An empty capabilities array satisfies is_array() without granting any role.
+	return array( array() );
 }
 
 /**

--- a/tests/settings/test-application-passwords.php
+++ b/tests/settings/test-application-passwords.php
@@ -156,6 +156,59 @@ class Test_WPorg_Two_Factor_Application_Passwords extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Verify that a user who is not a member of the current blog can still
+	 * revoke their own application password via the REST API.
+	 *
+	 * @covers WordPressdotorg\Two_Factor\allow_application_password_management
+	 */
+	public function test_non_member_can_revoke_application_password() : void {
+		wp_set_current_user( self::$regular_user->ID, self::$regular_user->user_login );
+
+		list( , $item ) = WP_Application_Passwords::create_new_application_password(
+			self::$regular_user->ID,
+			array( 'name' => 'Revoke Test' )
+		);
+
+		// Remove the user from the current blog to simulate profiles.wordpress.org.
+		$remove_user_callback = function ( $check, $user_id, $meta_key ) {
+			global $wpdb;
+
+			if ( $user_id !== self::$regular_user->ID ) {
+				return $check;
+			}
+
+			$blog_id          = get_current_blog_id();
+			$capabilities_key = $wpdb->base_prefix;
+			if ( 1 !== $blog_id ) {
+				$capabilities_key .= $blog_id . '_';
+			}
+			$capabilities_key .= 'capabilities';
+
+			if ( $meta_key !== $capabilities_key ) {
+				return $check;
+			}
+
+			// Return false wrapped in an array: get_metadata() unwraps one level,
+			// yielding false, which fails is_array() in is_user_member_of_blog().
+			return array( false );
+		};
+
+		add_filter( 'get_user_metadata', $remove_user_callback, 9, 3 );
+
+		$this->assertFalse(
+			is_user_member_of_blog( self::$regular_user->ID ),
+			'Precondition: user should not be a member of the blog.'
+		);
+
+		$request  = new WP_REST_Request( 'DELETE', '/wp/v2/users/' . self::$regular_user->ID . '/application-passwords/' . $item['uuid'] );
+		$response = rest_do_request( $request );
+
+		remove_filter( 'get_user_metadata', $remove_user_callback, 9 );
+
+		$this->assertSame( 200, $response->get_status(), 'Non-member should be able to revoke their own application password.' );
+	}
+
+	/**
 	 * @covers WordPressdotorg\Two_Factor\register_user_fields
 	 */
 	public function test_application_passwords_field_excludes_sensitive_data() : void {

--- a/tests/settings/test-application-passwords.php
+++ b/tests/settings/test-application-passwords.php
@@ -170,7 +170,7 @@ class Test_WPorg_Two_Factor_Application_Passwords extends WP_UnitTestCase {
 		);
 
 		// Remove the user from the current blog to simulate profiles.wordpress.org.
-		$remove_user_callback = function ( $check, $user_id, $meta_key ) {
+		$remove_user_callback = function( $check, $user_id, $meta_key ) {
 			global $wpdb;
 
 			if ( $user_id !== self::$regular_user->ID ) {
@@ -206,6 +206,15 @@ class Test_WPorg_Two_Factor_Application_Passwords extends WP_UnitTestCase {
 		remove_filter( 'get_user_metadata', $remove_user_callback, 9 );
 
 		$this->assertSame( 200, $response->get_status(), 'Non-member should be able to revoke their own application password.' );
+
+		$remaining_passwords = WP_Application_Passwords::get_user_application_passwords( self::$regular_user->ID );
+		$remaining_uuids     = wp_list_pluck( $remaining_passwords, 'uuid' );
+
+		$this->assertNotContains(
+			$item['uuid'],
+			$remaining_uuids,
+			'Application password should be removed after revocation.'
+		);
 	}
 
 	/**

--- a/tests/settings/test-application-passwords.php
+++ b/tests/settings/test-application-passwords.php
@@ -170,7 +170,7 @@ class Test_WPorg_Two_Factor_Application_Passwords extends WP_UnitTestCase {
 		);
 
 		// Remove the user from the current blog to simulate profiles.wordpress.org.
-		$remove_user_callback = function( $check, $user_id, $meta_key ) {
+		$remove_user_callback = function ( $check, $user_id, $meta_key ) {
 			global $wpdb;
 
 			if ( $user_id !== self::$regular_user->ID ) {

--- a/tests/settings/test-application-passwords.php
+++ b/tests/settings/test-application-passwords.php
@@ -159,7 +159,7 @@ class Test_WPorg_Two_Factor_Application_Passwords extends WP_UnitTestCase {
 	 * Verify that a user who is not a member of the current blog can still
 	 * revoke their own application password via the REST API.
 	 *
-	 * @covers WordPressdotorg\Two_Factor\allow_application_password_management
+	 * @covers WordPressdotorg\Two_Factor\treat_as_member_of_blog
 	 */
 	public function test_non_member_can_revoke_application_password() : void {
 		wp_set_current_user( self::$regular_user->ID, self::$regular_user->user_login );


### PR DESCRIPTION
## Summary

- Core's `WP_REST_Application_Passwords_Controller::get_user()` checks `is_user_member_of_blog()` on multisite and returns a 404 for non-members
- On profiles.wordpress.org, most users aren't members of that blog, so application password operations (revoke, revoke all) fail with "Invalid user ID"
- Filters `get_user_metadata` during application password REST requests to make `is_user_member_of_blog()` return true for the current user

Props @westonruter for reporting, @dd32 for identifying the root cause.

## Test plan

- [ ] Verify `npm test` passes (26 tests including new `test_non_member_can_revoke_application_password`)
- [ ] Verify `npm run lint:js` passes with 0 errors
- [ ] On a multisite, confirm a non-member user can revoke their own application passwords via the REST API

🤖 Generated with [Claude Code](https://claude.com/claude-code)