### PR TITLE
[codex] Add context to backup code downloads

### DIFF
--- a/settings/src/components/backup-codes.js
+++ b/settings/src/components/backup-codes.js
@@ -197,7 +197,10 @@ function CodeList( { codes } ) {
 				<ButtonGroup>
 					<CopyToClipboardButton contents={ backupCodesText } />
 					<PrintButton />
-					<DownloadButton contents={ backupCodesText } fileName="wordpress-org-backup-codes.txt" />
+					<DownloadButton
+						contents={ backupCodesText }
+						fileName="wordpress-org-backup-codes.txt"
+					/>
 				</ButtonGroup>
 			) }
 		</>

--- a/settings/src/components/backup-codes.js
+++ b/settings/src/components/backup-codes.js
@@ -165,6 +165,14 @@ function Setup( { setGenerating, onSuccess } ) {
  */
 function CodeList( { codes } ) {
 	const hasCodes = !! codes.length;
+	const backupCodesText = [
+		'Two-Factor backup codes for your WordPress.org account:',
+		'',
+		...codes.map( ( code, index ) => `${ index + 1 }. ${ code }` ),
+		'',
+		'Each code can only be used once.',
+		'These codes are the only way to recover your WordPress.org account if you lose access to your phone, authentication app, or other two-factor method.',
+	].join( '\n' );
 
 	return (
 		<>
@@ -187,9 +195,9 @@ function CodeList( { codes } ) {
 			</div>
 			{ hasCodes && (
 				<ButtonGroup>
-					<CopyToClipboardButton contents={ codes } />
+					<CopyToClipboardButton contents={ backupCodesText } />
 					<PrintButton />
-					<DownloadButton codes={ codes } />
+					<DownloadButton contents={ backupCodesText } fileName="wordpress-org-backup-codes.txt" />
 				</ButtonGroup>
 			) }
 		</>

--- a/settings/src/components/download-button.js
+++ b/settings/src/components/download-button.js
@@ -4,7 +4,10 @@
 import { useCallback } from '@wordpress/element';
 import { Button } from '@wordpress/components';
 
-export default function DownloadTxtButton( { contents, fileName = 'wordpress-org-backup-codes.txt' } ) {
+export default function DownloadTxtButton( {
+	contents,
+	fileName = 'wordpress-org-backup-codes.txt',
+} ) {
 	const downloadTxtFile = useCallback( () => {
 		const element = document.createElement( 'a' );
 		const file = new Blob( [ contents ], { type: 'text/plain' } );

--- a/settings/src/components/download-button.js
+++ b/settings/src/components/download-button.js
@@ -4,16 +4,16 @@
 import { useCallback } from '@wordpress/element';
 import { Button } from '@wordpress/components';
 
-export default function DownloadTxtButton( { codes, fileName = 'backup-codes.txt' } ) {
+export default function DownloadTxtButton( { contents, fileName = 'wordpress-org-backup-codes.txt' } ) {
 	const downloadTxtFile = useCallback( () => {
 		const element = document.createElement( 'a' );
-		const file = new Blob( [ codes ], { type: 'text/plain' } );
+		const file = new Blob( [ contents ], { type: 'text/plain' } );
 		element.href = URL.createObjectURL( file );
 		element.download = fileName;
 		document.body.appendChild( element ); // Required for Firefox
 		element.click();
 		document.body.removeChild( element );
-	}, [ codes, fileName ] );
+	}, [ contents, fileName ] );
 
 	return (
 		<Button variant="secondary" onClick={ downloadTxtFile }>


### PR DESCRIPTION
## What changed
- Add a WordPress.org-specific header to copied and downloaded backup-code text.
- Format saved backup codes as a numbered list.
- Append warnings that each code can only be used once and that the codes are needed to recover the WordPress.org account if the user loses access to their phone, authentication app, or other two-factor method.
- Rename the downloaded file to `wordpress-org-backup-codes.txt`.

## Why
The previous copy/download text was only the raw codes, and the downloaded filename was generic. Adding WordPress.org context makes the saved codes easier to identify later without including the username in the file.

Fixes #293.

## Validation
- Not run locally; branch pushed for GitHub Actions to run the PR checks.
